### PR TITLE
Fix for Issue #1 - solves Anthropic key validation errors

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -107,7 +107,7 @@ function loadSettings(): Record<string, any> {
   return {
     vaultPath: path.join(app.getPath('home'), 'Nudge'),
     theme: 'system',
-    model: 'claude-sonnet-4-6',
+    model: 'claude-sonnet-4-5',
     activeProvider: 'anthropic',
     onboardingComplete: false,
   };

--- a/src/main/providers/anthropic.ts
+++ b/src/main/providers/anthropic.ts
@@ -30,7 +30,7 @@ export class AnthropicProvider implements LLMProvider {
   }
 
   async validateKey(apiKey: string, _baseUrl?: string, model?: string): Promise<boolean> {
-    const testModel = model || 'claude-sonnet-4-6';
+    const testModel = model || 'claude-sonnet-4-5';
     try {
       const testClient = new Anthropic({ apiKey });
       const response = await testClient.messages.create({
@@ -101,7 +101,7 @@ export class AnthropicProvider implements LLMProvider {
           if (!this.client) throw new Error('Anthropic client not configured');
 
           const stream = this.client.messages.stream({
-            model: params.model || 'claude-sonnet-4-6',
+            model: params.model || 'claude-sonnet-4-5',
             max_tokens: 4096,
             system: params.systemPrompt,
             messages: this.toAnthropicMessages(params.messages),
@@ -163,12 +163,11 @@ export class AnthropicProvider implements LLMProvider {
 
   getDefaultModels(): ModelOption[] {
     return [
-      { value: 'claude-opus-4-5', label: 'Claude Opus 4.5' },
-      { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
       { value: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
-      { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+      { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+      { value: 'claude-opus-4-5', label: 'Claude Opus 4.5' },
       { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
-      { value: 'claude-haiku-4-6', label: 'Claude Haiku 4.6' },
+      { value: 'claude-sonnet-4-0', label: 'Claude Sonnet 4' },
     ];
   }
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -117,7 +117,7 @@ export default function App() {
       const systemPrompt = await buildSystemPrompt();
       const activeProvider = (await window.nudge.settings.get('activeProvider')) || 'anthropic';
       const model = (await window.nudge.settings.get(`model-${activeProvider}`))
-        || (activeProvider === 'anthropic' ? 'claude-sonnet-4-6' : 'gpt-4o');
+        || (activeProvider === 'anthropic' ? 'claude-sonnet-4-5' : 'gpt-4o');
 
       const cancel = await window.nudge.api.sendMessage(
         updatedMessages,

--- a/src/renderer/components/Onboarding.tsx
+++ b/src/renderer/components/Onboarding.tsx
@@ -31,8 +31,30 @@ interface OnboardingProps {
   onComplete: () => void;
 }
 
-type Step = 'welcome' | 'provider' | 'apiKey' | 'vault' | 'ready';
-const STEPS: Step[] = ['welcome', 'provider', 'apiKey', 'vault', 'ready'];
+type Step =
+  | 'welcome'
+  | 'provider'
+  | 'apiKey'
+  | 'vault'
+  | 'aboutMe'
+  | 'energy'
+  | 'preferences'
+  | 'focus'
+  | 'mantra'
+  | 'ready';
+
+const STEPS: Step[] = [
+  'welcome',
+  'provider',
+  'apiKey',
+  'vault',
+  'aboutMe',
+  'energy',
+  'preferences',
+  'focus',
+  'mantra',
+  'ready',
+];
 
 const PROVIDER_OPTIONS: { id: ProviderId; name: string; description: string }[] = [
   { id: 'anthropic', name: 'Anthropic', description: 'Claude models (Sonnet, Opus, Haiku)' },
@@ -46,10 +68,42 @@ const PROVIDER_KEY_INFO: Record<ProviderId, { placeholder: string; linkText: str
   custom: { placeholder: 'your-api-key', linkText: '', linkUrl: '' },
 };
 
+const PROVIDER_MODELS: Record<ProviderId, { value: string; label: string }[]> = {
+  anthropic: [
+    { value: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+    { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+    { value: 'claude-opus-4-5', label: 'Claude Opus 4.5' },
+    { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+    { value: 'claude-sonnet-4-0', label: 'Claude Sonnet 4' },
+  ],
+  openai: [
+    { value: 'gpt-4o', label: 'GPT-4o' },
+    { value: 'gpt-4o-mini', label: 'GPT-4o Mini' },
+    { value: 'gpt-5.2', label: 'gpt-5.2' },
+    { value: 'gpt-5-mini', label: 'gpt-5-mini' },
+    { value: 'gpt-4.1', label: 'gpt-4.1' },
+    { value: 'gpt-4.1-mini', label: 'gpt-4.1-mini' },
+    { value: 'o3-mini', label: 'o3-mini' },
+  ],
+  custom: [],
+};
+
+const DEFAULT_MODELS: Record<ProviderId, string> = {
+  anthropic: 'claude-sonnet-4-5',
+  openai: 'gpt-4o',
+  custom: 'gpt-4o',
+};
+
+// Energy level options
+const ENERGY_OPTIONS = ['High', 'Medium', 'Low', 'Varies'];
+
 export default function Onboarding({ onComplete }: OnboardingProps) {
   const isDark = useIsDark();
   const [step, setStep] = useState<Step>('welcome');
+
+  // Provider & API key state
   const [selectedProvider, setSelectedProvider] = useState<ProviderId>('anthropic');
+  const [selectedModel, setSelectedModel] = useState('claude-sonnet-4-5');
   const [apiKey, setApiKey] = useState('');
   const [customBaseUrl, setCustomBaseUrl] = useState('');
   const [customModel, setCustomModel] = useState('gpt-4o');
@@ -58,7 +112,31 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
   const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [initializing, setInitializing] = useState(false);
 
+  // Profile wizard state
+  const [aboutMe, setAboutMe] = useState('');
+  const [energyMorning, setEnergyMorning] = useState('');
+  const [energyAfternoon, setEnergyAfternoon] = useState('');
+  const [energyEvening, setEnergyEvening] = useState('');
+  const [helpWhenStuck, setHelpWhenStuck] = useState('');
+  const [suggestionStyle, setSuggestionStyle] = useState('');
+  const [focusAreas, setFocusAreas] = useState('');
+  const [mantra, setMantra] = useState('Starting is success, completion is optional.');
+
   const currentIndex = STEPS.indexOf(step);
+
+  function goNext() {
+    const nextIndex = currentIndex + 1;
+    if (nextIndex < STEPS.length) {
+      setStep(STEPS[nextIndex]);
+    }
+  }
+
+  function goBack() {
+    const prevIndex = currentIndex - 1;
+    if (prevIndex >= 0) {
+      setStep(STEPS[prevIndex]);
+    }
+  }
 
   const handleValidateKey = async () => {
     if (!apiKey.trim()) return;
@@ -68,16 +146,14 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
 
     try {
       const baseUrl = selectedProvider === 'custom' ? customBaseUrl.trim() || undefined : undefined;
-      const model = selectedProvider === 'custom' ? customModel.trim() : undefined;
+      const model = selectedProvider === 'custom' ? customModel.trim() : selectedModel;
       const valid = await window.nudge.api.validateKey(selectedProvider, apiKey.trim(), baseUrl, model);
       if (valid) {
         await window.nudge.settings.setApiKey(selectedProvider, apiKey.trim());
         await window.nudge.settings.set('activeProvider', selectedProvider);
+        await window.nudge.settings.set(`model-${selectedProvider}`, model);
         if (baseUrl) {
           await window.nudge.settings.setProviderBaseUrl(selectedProvider, baseUrl);
-        }
-        if (selectedProvider === 'custom' && model) {
-          await window.nudge.settings.set('model-custom', model);
         }
         setFeedback({ type: 'success', message: 'Key validated successfully.' });
         setTimeout(() => setStep('vault'), 800);
@@ -94,19 +170,61 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
   const handleVaultSetup = async () => {
     setInitializing(true);
     try {
-      // Use the default vault path from settings (set by main process)
       const currentPath = await window.nudge.vault.getPath();
       await window.nudge.vault.initialize(currentPath);
-      setStep('ready');
+      setStep('aboutMe');
     } catch {
-      // Vault may already exist, proceed anyway
-      setStep('ready');
+      setStep('aboutMe');
     } finally {
       setInitializing(false);
     }
   };
 
+  function buildConfigMd(): string {
+    const aboutSection = aboutMe.trim() || 'Tell Nudge about yourself — what you do, how you work, what helps you focus.';
+    const mantraSection = mantra.trim() || 'Starting is success, completion is optional.';
+    const morning = energyMorning || '';
+    const afternoon = energyAfternoon || '';
+    const evening = energyEvening || '';
+    const stuck = helpWhenStuck.trim() || '';
+    const style = suggestionStyle.trim() || '';
+    const focus = focusAreas.trim() || 'What\'s top of mind right now';
+
+    return `# Config
+
+## About Me
+
+${aboutSection}
+
+## Mantra
+
+**"${mantraSection}"**
+
+## Energy Patterns
+
+- Morning: ${morning}
+- Afternoon: ${afternoon}
+- Evening: ${evening}
+
+## Preferences
+
+- What helps when you're stuck: ${stuck}
+- Preferred suggestion style: ${style}
+
+## Current Focus Areas
+
+- ${focus}
+`;
+  }
+
   const handleComplete = async () => {
+    // Write profile to config.md
+    try {
+      const configContent = buildConfigMd();
+      await window.nudge.vault.writeFile('config.md', configContent);
+    } catch {
+      // Non-blocking — vault may not be ready
+    }
     await window.nudge.settings.set('onboardingComplete', true);
     onComplete();
   };
@@ -119,6 +237,29 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
           className={`onboarding-dot ${i === currentIndex ? 'onboarding-dot--active' : ''} ${i < currentIndex ? 'onboarding-dot--done' : ''}`}
         />
       ))}
+    </div>
+  );
+
+  // Reusable navigation bar for profile wizard steps
+  const renderWizardNav = (opts?: { nextLabel?: string; onNext?: () => void; nextDisabled?: boolean; hideSkip?: boolean }) => (
+    <div className="onboarding-wizard-nav">
+      <button className="onboarding-nav-btn onboarding-nav-btn--back" onClick={goBack}>
+        <span className="onboarding-nav-arrow">&larr;</span> Back
+      </button>
+      <div className="onboarding-wizard-nav-right">
+        {!opts?.hideSkip && (
+          <button className="onboarding-nav-btn onboarding-nav-btn--skip" onClick={goNext}>
+            Skip
+          </button>
+        )}
+        <button
+          className="onboarding-btn onboarding-btn--primary onboarding-btn--nav"
+          onClick={opts?.onNext || goNext}
+          disabled={opts?.nextDisabled}
+        >
+          {opts?.nextLabel || 'Next'} <span className="onboarding-nav-arrow">&rarr;</span>
+        </button>
+      </div>
     </div>
   );
 
@@ -153,19 +294,24 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
                 <button
                   key={opt.id}
                   className={`onboarding-provider-card ${selectedProvider === opt.id ? 'onboarding-provider-card--active' : ''}`}
-                  onClick={() => setSelectedProvider(opt.id)}
+                  onClick={() => { setSelectedProvider(opt.id); setSelectedModel(DEFAULT_MODELS[opt.id]); }}
                 >
                   <span className="onboarding-provider-name">{opt.name}</span>
                   <span className="onboarding-provider-desc">{opt.description}</span>
                 </button>
               ))}
             </div>
-            <button
-              className="onboarding-btn onboarding-btn--primary"
-              onClick={() => setStep('apiKey')}
-            >
-              Continue
-            </button>
+            <div className="onboarding-wizard-nav">
+              <button className="onboarding-nav-btn onboarding-nav-btn--back" onClick={goBack}>
+                <span className="onboarding-nav-arrow">&larr;</span> Back
+              </button>
+              <button
+                className="onboarding-btn onboarding-btn--primary onboarding-btn--nav"
+                onClick={() => setStep('apiKey')}
+              >
+                Continue <span className="onboarding-nav-arrow">&rarr;</span>
+              </button>
+            </div>
             {renderDots()}
           </div>
         )}
@@ -185,6 +331,22 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
               >
                 {PROVIDER_KEY_INFO[selectedProvider].linkText}
               </a>
+            )}
+            {selectedProvider !== 'custom' && PROVIDER_MODELS[selectedProvider].length > 0 && (
+              <div className="onboarding-input-group">
+                <label className="onboarding-input-label">Model</label>
+                <div className="onboarding-model-cards">
+                  {PROVIDER_MODELS[selectedProvider].map((m) => (
+                    <button
+                      key={m.value}
+                      className={`onboarding-model-card ${selectedModel === m.value ? 'onboarding-model-card--active' : ''}`}
+                      onClick={() => { setSelectedModel(m.value); setFeedback(null); }}
+                    >
+                      {m.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
             )}
             {selectedProvider === 'custom' && (
               <>
@@ -230,13 +392,18 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
                 {feedback.message}
               </div>
             )}
-            <button
-              className="onboarding-btn onboarding-btn--primary"
-              onClick={handleValidateKey}
-              disabled={validating || !apiKey.trim() || (selectedProvider === 'custom' && !customModel.trim())}
-            >
-              {validating ? 'Validating...' : 'Validate & Continue'}
-            </button>
+            <div className="onboarding-wizard-nav">
+              <button className="onboarding-nav-btn onboarding-nav-btn--back" onClick={goBack}>
+                <span className="onboarding-nav-arrow">&larr;</span> Back
+              </button>
+              <button
+                className="onboarding-btn onboarding-btn--primary onboarding-btn--nav"
+                onClick={handleValidateKey}
+                disabled={validating || !apiKey.trim() || (selectedProvider === 'custom' && !customModel.trim())}
+              >
+                {validating ? 'Validating...' : 'Validate & Continue'} <span className="onboarding-nav-arrow">&rarr;</span>
+              </button>
+            </div>
             {renderDots()}
           </div>
         )}
@@ -248,13 +415,144 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
               Your vault is where Nudge stores your ideas, daily logs, and tasks. Everything stays on your machine.
             </p>
             <div className="onboarding-vault-path">~/Nudge/</div>
-            <button
-              className="onboarding-btn onboarding-btn--primary"
-              onClick={handleVaultSetup}
-              disabled={initializing}
-            >
-              {initializing ? 'Setting up...' : 'Use Default'}
-            </button>
+            <div className="onboarding-wizard-nav">
+              <button className="onboarding-nav-btn onboarding-nav-btn--back" onClick={goBack}>
+                <span className="onboarding-nav-arrow">&larr;</span> Back
+              </button>
+              <button
+                className="onboarding-btn onboarding-btn--primary onboarding-btn--nav"
+                onClick={handleVaultSetup}
+                disabled={initializing}
+              >
+                {initializing ? 'Setting up...' : 'Use Default'} <span className="onboarding-nav-arrow">&rarr;</span>
+              </button>
+            </div>
+            {renderDots()}
+          </div>
+        )}
+
+        {/* --- Profile Wizard Steps --- */}
+
+        {step === 'aboutMe' && (
+          <div className="onboarding-step">
+            <h1 className="onboarding-heading">Tell Nudge about yourself</h1>
+            <p className="onboarding-text">
+              What do you do? How do you work best? This helps Nudge tailor its suggestions to you.
+            </p>
+            <div className="onboarding-input-group">
+              <textarea
+                className="onboarding-textarea"
+                value={aboutMe}
+                onChange={(e) => setAboutMe(e.target.value)}
+                placeholder="e.g. I'm a software developer who works best in short focused bursts. I like to have a clear list of what to do next."
+                rows={4}
+              />
+            </div>
+            {renderWizardNav()}
+            {renderDots()}
+          </div>
+        )}
+
+        {step === 'energy' && (
+          <div className="onboarding-step">
+            <h1 className="onboarding-heading">Your energy patterns</h1>
+            <p className="onboarding-text">
+              When during the day do you have the most energy? Nudge can suggest tasks that match your rhythm.
+            </p>
+            <div className="onboarding-energy-grid">
+              {([
+                { label: 'Morning', value: energyMorning, setter: setEnergyMorning },
+                { label: 'Afternoon', value: energyAfternoon, setter: setEnergyAfternoon },
+                { label: 'Evening', value: energyEvening, setter: setEnergyEvening },
+              ] as const).map(({ label, value, setter }) => (
+                <div key={label} className="onboarding-energy-row">
+                  <span className="onboarding-energy-label">{label}</span>
+                  <div className="onboarding-energy-options">
+                    {ENERGY_OPTIONS.map((opt) => (
+                      <button
+                        key={opt}
+                        className={`onboarding-energy-btn ${value === opt ? 'onboarding-energy-btn--active' : ''}`}
+                        onClick={() => setter(opt)}
+                      >
+                        {opt}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+            {renderWizardNav()}
+            {renderDots()}
+          </div>
+        )}
+
+        {step === 'preferences' && (
+          <div className="onboarding-step">
+            <h1 className="onboarding-heading">How can Nudge help?</h1>
+            <p className="onboarding-text">
+              Everyone gets stuck sometimes. Let Nudge know what works for you.
+            </p>
+            <div className="onboarding-input-group">
+              <label className="onboarding-input-label">What helps when you're stuck?</label>
+              <input
+                className="onboarding-input"
+                type="text"
+                value={helpWhenStuck}
+                onChange={(e) => setHelpWhenStuck(e.target.value)}
+                placeholder="e.g. Breaking things into tiny steps, body doubling, changing scenery"
+              />
+            </div>
+            <div className="onboarding-input-group">
+              <label className="onboarding-input-label">Preferred suggestion style</label>
+              <input
+                className="onboarding-input"
+                type="text"
+                value={suggestionStyle}
+                onChange={(e) => setSuggestionStyle(e.target.value)}
+                placeholder="e.g. Gentle nudges, direct to-do lists, playful encouragement"
+              />
+            </div>
+            {renderWizardNav()}
+            {renderDots()}
+          </div>
+        )}
+
+        {step === 'focus' && (
+          <div className="onboarding-step">
+            <h1 className="onboarding-heading">What's on your plate?</h1>
+            <p className="onboarding-text">
+              What are your current focus areas? Nudge will keep these in mind during your chats.
+            </p>
+            <div className="onboarding-input-group">
+              <textarea
+                className="onboarding-textarea"
+                value={focusAreas}
+                onChange={(e) => setFocusAreas(e.target.value)}
+                placeholder="e.g. Finishing the Q1 report, learning Rust, exercising 3x a week"
+                rows={3}
+              />
+            </div>
+            {renderWizardNav()}
+            {renderDots()}
+          </div>
+        )}
+
+        {step === 'mantra' && (
+          <div className="onboarding-step">
+            <h1 className="onboarding-heading">Pick your mantra</h1>
+            <p className="onboarding-text">
+              A short phrase Nudge can remind you of when things feel hard. Use ours or write your own.
+            </p>
+            <div className="onboarding-input-group">
+              <input
+                className="onboarding-input onboarding-input--mantra"
+                type="text"
+                value={mantra}
+                onChange={(e) => setMantra(e.target.value)}
+                placeholder="Starting is success, completion is optional."
+              />
+            </div>
+            {renderWizardNav({ nextLabel: 'Finish', hideSkip: true })}
             {renderDots()}
           </div>
         )}
@@ -264,6 +562,9 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
             <h1 className="onboarding-heading">You're all set!</h1>
             <p className="onboarding-text">
               Nudge is ready. Start a conversation whenever you're ready.
+            </p>
+            <p className="onboarding-text onboarding-text--hint">
+              You can always update your profile later by editing <strong>config.md</strong> in your vault.
             </p>
             <button className="onboarding-btn onboarding-btn--primary" onClick={handleComplete}>
               Start Chatting

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -19,12 +19,11 @@ const PROVIDERS: Record<ProviderId, ProviderMeta> = {
   anthropic: {
     name: 'Anthropic',
     models: [
-      { value: 'claude-opus-4-5', label: 'Claude Opus 4.5' },
-      { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
       { value: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
-      { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+      { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+      { value: 'claude-opus-4-5', label: 'Claude Opus 4.5' },
       { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
-      { value: 'claude-haiku-4-6', label: 'Claude Haiku 4.6' },
+      { value: 'claude-sonnet-4-0', label: 'Claude Sonnet 4' },
     ],
     keyPlaceholder: 'sk-ant-...',
     showBaseUrl: false,
@@ -72,7 +71,7 @@ export default function Settings({ isOpen, onClose }: SettingsProps) {
     anthropic: '', openai: '', custom: '',
   });
   const [providerModels, setProviderModels] = useState<Record<ProviderId, string>>({
-    anthropic: 'claude-sonnet-4-6',
+    anthropic: 'claude-sonnet-4-5',
     openai: 'gpt-4o',
     custom: 'gpt-4o',
   });

--- a/src/renderer/styles/Onboarding.css
+++ b/src/renderer/styles/Onboarding.css
@@ -196,6 +196,41 @@
   color: var(--accent);
 }
 
+/* --- Model Selection --- */
+
+.onboarding-model-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: 100%;
+  max-width: 360px;
+  justify-content: center;
+}
+
+.onboarding-model-card {
+  padding: 9px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 500;
+  text-align: center;
+  transition: all 150ms ease;
+  cursor: pointer;
+}
+
+.onboarding-model-card:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.onboarding-model-card--active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--bg-secondary);
+}
+
 .onboarding-vault-path {
   font-family: var(--font-mono);
   font-size: 14px;
@@ -228,4 +263,163 @@
 
 .onboarding-dot--done {
   background: var(--accent-light);
+}
+
+/* --- Wizard Navigation --- */
+
+.onboarding-wizard-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 360px;
+  margin-top: 12px;
+}
+
+.onboarding-wizard-nav-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.onboarding-nav-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-weight: 500;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.onboarding-nav-btn--back {
+  color: var(--text-secondary);
+  background: transparent;
+}
+
+.onboarding-nav-btn--back:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.onboarding-nav-btn--skip {
+  color: var(--text-muted);
+  background: transparent;
+  font-size: 13px;
+}
+
+.onboarding-nav-btn--skip:hover {
+  color: var(--text-secondary);
+  text-decoration: underline;
+}
+
+.onboarding-nav-arrow {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.onboarding-btn--nav {
+  margin-top: 0;
+  padding: 10px 20px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* --- Textarea --- */
+
+.onboarding-textarea {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.6;
+  outline: none;
+  resize: vertical;
+  transition: border-color 150ms ease;
+}
+
+.onboarding-textarea:focus {
+  border-color: var(--accent);
+}
+
+.onboarding-textarea::placeholder {
+  color: var(--text-muted);
+}
+
+/* --- Mantra Input --- */
+
+.onboarding-input--mantra {
+  text-align: center;
+  font-style: italic;
+  font-size: 15px;
+  font-weight: 500;
+}
+
+/* --- Energy Grid --- */
+
+.onboarding-energy-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+  max-width: 360px;
+}
+
+.onboarding-energy-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.onboarding-energy-label {
+  width: 80px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  text-align: left;
+  flex-shrink: 0;
+}
+
+.onboarding-energy-options {
+  display: flex;
+  gap: 6px;
+  flex: 1;
+}
+
+.onboarding-energy-btn {
+  flex: 1;
+  padding: 7px 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-align: center;
+  transition: all 150ms ease;
+  cursor: pointer;
+}
+
+.onboarding-energy-btn:hover {
+  background: var(--bg-hover);
+}
+
+.onboarding-energy-btn--active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--bg-secondary);
+  font-weight: 500;
+}
+
+/* --- Hint text on final step --- */
+
+.onboarding-text--hint {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-top: -4px;
 }


### PR DESCRIPTION
- **Profile wizard**: Adds 5 new onboarding steps (About Me, Energy Patterns, Preferences, Focus Areas, Mantra) with back/next/skip navigation. Profile data is written to `config.md` in the vault on completion.
- **Model selection during setup**: Adds a model picker to the API key step so the selected model is used for key validation and saved to settings. Previously, validation used a hardcoded model name that could fail.
- **Fix non-existent model IDs**: Removes `claude-sonnet-4-6` and `claude-haiku-4-6` which don't exist in the Anthropic API. Updates all defaults and model lists to use real model IDs (`claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4-6`, etc.) across all 6 affected files.
