### PR TITLE
Fix editor line numbers, add word wrap toggle, and restore system shortcuts

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, shell, Menu } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 import { getProvider, resetProvider } from './providers/registry';
@@ -640,6 +640,75 @@ app.whenReady().then(async () => {
   devLog('lifecycle', 'app ready');
   devLog('lifecycle', 'dev log file', { path: path.join(app.getPath('userData'), DEV_LOG_DIR, DEV_LOG_FILE) });
   await migrateApiKey();
+
+  // Set up application menu so standard shortcuts (Cmd+Q, Cmd+C, etc.) work
+  const template: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: app.name,
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    },
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: 'Save',
+          accelerator: 'CmdOrCtrl+S',
+          click: () => {
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send('menu:save');
+            }
+          },
+        },
+        { type: 'separator' },
+        { role: 'close' },
+      ],
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' },
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        { type: 'separator' },
+        { role: 'front' },
+      ],
+    },
+  ];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+
   createWindow();
 
   app.on('activate', () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -119,6 +119,11 @@ async function invoke<T>(channel: string, ...args: any[]): Promise<T> {
 contextBridge.exposeInMainWorld('nudge', {
   app: {
     getSystemPrompt: () => invoke<string>('app:get-system-prompt'),
+    onMenuSave: (callback: () => void) => {
+      const handler = () => callback();
+      ipcRenderer.on('menu:save', handler);
+      return () => { ipcRenderer.removeListener('menu:save', handler); };
+    },
   },
   vault: {
     readFile: (path: string) => invoke('vault:read-file', path),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -40,6 +40,7 @@ export interface ToolUseRequest {
 export interface NudgeAPI {
   app: {
     getSystemPrompt: () => Promise<string>;
+    onMenuSave: (callback: () => void) => () => void;
   };
   vault: {
     readFile: (path: string) => Promise<string>;


### PR DESCRIPTION
## Summary
- Fixed line numbers disappearing when scrolling by using a MutationObserver to reliably attach the scroll listener after the MDEditor renders its DOM elements
- Fixed gutter height overflow by constraining it to `calc(100% - 35px)` to account for the toolbar margin
- Disabled word wrapping by default (`white-space: pre`) so each logical line maps 1:1 to a line number, preventing gutter drift from wrapped lines
- Added a **Word Wrap** toggle button in the editor toolbar that enables `pre-wrap` and dynamically measures each line's rendered height via an offscreen `<pre>` element, adjusting gutter line-number divs to match wrapped line heights
- Line height measurement uses a `ResizeObserver` to re-measure on editor width changes and re-runs on content edits
- Added a proper Electron application menu with standard macOS roles (Quit, Copy, Cut, Paste, Undo, Redo, Select All, etc.) — previously no menu was defined, so system shortcuts were non-functional
- Wired Cmd+S through the menu to trigger an immediate file save in the editor via IPC (`menu:save`)
- Added a capturing-phase keydown handler on the editor container to prevent the MDEditor textarea from swallowing Cmd/Ctrl key combos (Cmd+Q was inserting characters instead of quitting)

## Test plan
- [x] Open a file with 50+ lines, scroll to the bottom, then scroll back up — line numbers should be visible the entire time
- [x] Open a file with long lines — with wrap OFF, lines scroll horizontally and line numbers stay aligned
- [x] Toggle wrap ON — long lines wrap and each line number stretches to match the visual height of its wrapped line
- [x] Resize the window while wrap is ON — line numbers re-align after resize
- [x] Toggle line numbers OFF then ON while wrap is active — gutter re-appears with correct heights
- [ ] With the editor focused, press Cmd+Q — app should quit (no characters inserted)
- [ ] With the editor focused, press Cmd+C / Cmd+V / Cmd+X — copy/paste/cut should work normally
- [ ] With the editor focused, press Cmd+S — file should save immediately (status shows "Saved")
- [ ] With the editor focused, press Cmd+Z / Cmd+Shift+Z — undo/redo should work within the editor
- [ ] With the editor focused, press Cmd+A — select all should work within the editor