### PR TITLE
Fix GitHub Releases requiring a tag on manual workflow_dispatch

### DIFF
--- a/.github/workflows/release-electron.yml
+++ b/.github/workflows/release-electron.yml
@@ -6,6 +6,10 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
     inputs:
+      tag:
+        description: 'Tag to release (e.g. v0.2.0)'
+        required: true
+        type: string
       draft:
         description: 'Create as draft release'
         required: false
@@ -250,6 +254,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           draft: ${{ steps.draft.outputs.is_draft == 'true' }}
           generate_release_notes: true
           files: |


### PR DESCRIPTION
The softprops/action-gh-release action needs a tag_name to create a
release. Tag-push triggers provide this automatically via github.ref,
but manual workflow_dispatch runs do not. Added a required "tag" input
to workflow_dispatch and passed it as tag_name to the release step,
falling back to github.ref_name for tag-triggered runs.

https://claude.ai/code/session_015FhX3SGreZ2w1bEfc6fBy7