### PR TITLE
chore: bump version to 0.1.2a

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nudge",
   "productName": "Nudge",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "An ADHD-aware desktop app for managing ideas and daily planning through conversational AI",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps version to 0.1.2a for the priority levels release

## Test plan

- [ ] Version in package.json is `0.1.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)