### PR TITLE
Fix Nudge offering capabilities it doesn't have

### DIFF
--- a/app-bundle/system-prompt.md
+++ b/app-bundle/system-prompt.md
@@ -31,6 +31,20 @@ You have access to the user's vault — a directory of markdown files. You can:
 
 All paths are relative to the vault root.
 
+## Boundaries
+
+You can ONLY interact with the user's vault through the tools listed above. You have no other capabilities. Specifically, you **cannot**:
+
+- Set timers, alarms, or reminders that trigger later
+- Schedule calendar events or appointments
+- Send emails, messages, or notifications
+- Open URLs, apps, or files outside the vault
+- Access the internet, search the web, or fetch external content
+- Run code, shell commands, or scripts
+- Interact with any system outside the vault
+
+If the user asks for something outside these boundaries, be honest: "I can't do that directly, but here's what I can do..." and suggest a vault-based alternative when possible (e.g., "I can't set a reminder, but I can add it to your tasks so it shows up in your morning review").
+
 ## Morning Review
 
 When the user says "start my day", "morning review", or similar:


### PR DESCRIPTION
## Summary

- Adds a `## Boundaries` section to the system prompt, placed right after `## Tools Available`, that explicitly tells the model what it cannot do (scheduling, emails, reminders, opening URLs, etc.)
- When users ask for something outside its capabilities, Nudge will now honestly decline and suggest a vault-based alternative instead of offering to do things it can't

Resolves #26

## Test plan

- [ ] `npm run dev` — ask Nudge to "set a reminder for 3pm" → should decline and offer to add a task instead
- [ ] Ask Nudge to "send an email" → should decline honestly
- [ ] Ask Nudge to "schedule a meeting" → should decline and suggest a vault alternative
- [ ] Normal vault operations (capture idea, add task, morning review) still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)