### PR TITLE
fix: prevent sha512 line-wrapping in update YAML files

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -25,6 +25,7 @@ win:
     codeSigningAccountName: "nudgesigning"
 linux:
   target: AppImage
+afterAllArtifactBuild: scripts/fix-update-yml.js
 publish:
   provider: github
   owner: thatsjet

--- a/scripts/fix-update-yml.js
+++ b/scripts/fix-update-yml.js
@@ -1,0 +1,33 @@
+/**
+ * afterAllArtifactBuild hook for electron-builder.
+ * Fixes the sha512 line-wrapping issue in latest-*.yml files where
+ * base64 strings wrap at 76 chars without YAML multiline syntax,
+ * causing js-yaml parse failures in electron-updater.
+ */
+const fs = require('fs');
+const path = require('path');
+
+module.exports = async function (context) {
+  const outputDir = context.outDir;
+  const ymlFiles = fs.readdirSync(outputDir).filter(f => f.match(/^latest.*\.yml$/));
+
+  for (const file of ymlFiles) {
+    const filePath = path.join(outputDir, file);
+    let content = fs.readFileSync(filePath, 'utf8');
+
+    // Fix sha512 values that are split across lines.
+    // Match "sha512: <base64>" where the base64 continues on the next line
+    // (next line starts with non-space content that looks like base64 continuation)
+    content = content.replace(
+      /^(\s+sha512:\s+)(\S+)\n(\s+)(\S+==)$/gm,
+      (match, prefix, part1, indent, part2) => {
+        return `${prefix}${part1}${part2}`;
+      }
+    );
+
+    fs.writeFileSync(filePath, content, 'utf8');
+    console.log(`Fixed YAML line wrapping in ${file}`);
+  }
+
+  return [];
+};


### PR DESCRIPTION
## Summary
- Adds `afterAllArtifactBuild` hook to fix electron-builder's sha512 line-wrapping bug in `latest-*.yml` files
- Also manually fixed the existing `latest-mac.yml` in the v0.1.3 release

## Context
electron-builder v26.7.0 wraps long sha512 base64 strings at 76 chars without proper YAML multiline syntax, causing `electron-updater` to fail with a `YAMLException` when checking for updates.

## Test plan
- [ ] Run `npm run build` and verify `latest-mac.yml` has sha512 on a single line
- [ ] Confirm update check no longer throws YAML parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)