### PR TITLE
fix: prevent base64 line-wrapping in update metadata

### DIFF
--- a/.github/workflows/release-electron.yml
+++ b/.github/workflows/release-electron.yml
@@ -253,7 +253,7 @@ jobs:
             local file="$1"
             local output="$2"
             if [ ! -f "$file" ]; then return; fi
-            local sha512=$(shasum -a 512 "$file" | awk '{print $1}' | xxd -r -p | base64)
+            local sha512=$(shasum -a 512 "$file" | awk '{print $1}' | xxd -r -p | base64 -w 0)
             local size=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file" 2>/dev/null)
             local filename=$(basename "$file")
             cat > "$output" <<EOF

--- a/scripts/fix-update-yml.js
+++ b/scripts/fix-update-yml.js
@@ -3,9 +3,53 @@
  * Fixes the sha512 line-wrapping issue in latest-*.yml files where
  * base64 strings wrap at 76 chars without YAML multiline syntax,
  * causing js-yaml parse failures in electron-updater.
+ *
+ * Handles edge cases:
+ *  - Any hash field (sha512, sha256, etc.)
+ *  - Base64 with =, ==, or no padding
+ *  - Multiple continuation lines from very long values
+ *  - Continuation lines with or without leading whitespace
  */
 const fs = require('fs');
 const path = require('path');
+
+function fixWrappedHashes(content) {
+  const lines = content.split('\n');
+  const result = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    // Match a line containing a hash field with a base64 value
+    // Handles both indented (  sha512: ...) and top-level (sha512: ...)
+    const hashMatch = line.match(/^(\s*sha\d+:\s+)([A-Za-z0-9+/]+=*)$/);
+
+    if (hashMatch) {
+      // Check if subsequent lines are base64 continuations:
+      // - only base64 characters (letters, digits, +, /, =)
+      // - not a YAML key (no colon after text)
+      // - optionally preceded by whitespace
+      let joined = line;
+      while (i + 1 < lines.length) {
+        const nextLine = lines[i + 1];
+        const contMatch = nextLine.match(/^\s*([A-Za-z0-9+/]+=*)\s*$/);
+        // Stop if it looks like a YAML key (contains ": " or ends with ":")
+        if (contMatch && !nextLine.includes(': ') && !nextLine.match(/:\s*$/)) {
+          joined += contMatch[1];
+          i++;
+        } else {
+          break;
+        }
+      }
+      result.push(joined);
+    } else {
+      result.push(line);
+    }
+    i++;
+  }
+
+  return result.join('\n');
+}
 
 module.exports = async function (buildResult) {
   const outputDir = buildResult.outDir;
@@ -13,19 +57,27 @@ module.exports = async function (buildResult) {
 
   for (const file of ymlFiles) {
     const filePath = path.join(outputDir, file);
-    let content = fs.readFileSync(filePath, 'utf8');
+    const original = fs.readFileSync(filePath, 'utf8');
+    const fixed = fixWrappedHashes(original);
 
-    // Fix sha512 values that are split across lines.
-    // electron-builder wraps base64 at 76 chars, with the continuation
-    // on the next line with no indentation — join them back together.
-    content = content.replace(
-      /(sha512:\s+\S+)\n(\S+==)/g,
-      '$1$2'
-    );
-
-    fs.writeFileSync(filePath, content, 'utf8');
-    console.log(`Fixed YAML line wrapping in ${file}`);
+    if (fixed !== original) {
+      fs.writeFileSync(filePath, fixed, 'utf8');
+      console.log(`Fixed YAML line wrapping in ${file}`);
+    }
   }
 
   return [];
 };
+
+// Allow direct invocation for testing: node fix-update-yml.js <file>
+if (require.main === module && process.argv[2]) {
+  const filePath = process.argv[2];
+  const original = fs.readFileSync(filePath, 'utf8');
+  const fixed = fixWrappedHashes(original);
+  if (fixed !== original) {
+    fs.writeFileSync(filePath, fixed, 'utf8');
+    console.log('Fixed:', filePath);
+  } else {
+    console.log('No changes needed:', filePath);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `base64 -w 0` to CI release workflow to prevent sha512 line-wrapping in `latest-*.yml` files
- Improves `afterAllArtifactBuild` hook as a safety net for local builds, handling multiple continuation lines, all base64 padding variants, and other hash algorithms

## Context
The `generate_metadata` function in the release workflow pipes through `base64`, which wraps at 76 chars by default on Linux. This broke `electron-updater`'s YAML parsing, preventing update checks from working on v0.1.3 and v0.1.4. Both releases have been manually patched.

## Test plan
- [ ] Trigger a release build and verify `latest-mac.yml` has sha512 on a single line
- [ ] Confirm update check parses without YAML errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)