### PR TITLE
fix: use zip for macOS auto-update metadata

### DIFF
--- a/.github/workflows/release-electron.yml
+++ b/.github/workflows/release-electron.yml
@@ -269,10 +269,10 @@ jobs:
             echo "Generated $output for $filename"
           }
 
-          # macOS
-          DMG=$(ls *.dmg 2>/dev/null | head -1)
-          if [ -n "$DMG" ]; then
-            generate_metadata "$DMG" "latest-mac.yml"
+          # macOS (auto-updater requires zip, not dmg)
+          ZIP=$(ls *.zip 2>/dev/null | head -1)
+          if [ -n "$ZIP" ]; then
+            generate_metadata "$ZIP" "latest-mac.yml"
           fi
 
           # Windows

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -12,7 +12,7 @@ icon: icon.png
 mac:
   target:
     - dmg
-    - dir
+    - zip
   category: public.app-category.productivity
   icon: icon.png
 win:


### PR DESCRIPTION
## Summary
- Build `zip` instead of `dir` target for macOS so auto-updater has the archive it needs
- Point `latest-mac.yml` at the zip instead of the dmg in CI metadata generation
- DMG still built for manual downloads

## Context
`electron-updater` requires a `.zip` archive for macOS updates. The previous config only built DMG + dir, causing the "ZIP file not provided" error. Windows (NSIS `.exe`) and Linux (AppImage) targets already work correctly with electron-updater.

## Test plan
- [ ] Trigger a release build and verify both `.dmg` and `.zip` are in the release assets
- [ ] Verify `latest-mac.yml` references the `.zip` file
- [ ] Confirm in-app update check succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)