### PR TITLE
test: add vitest test infrastructure

### DIFF
--- a/docs/plans/2026-02-22-test-infrastructure.md
+++ b/docs/plans/2026-02-22-test-infrastructure.md
@@ -1,0 +1,891 @@
+# Test Infrastructure Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Set up Vitest with comprehensive unit tests for main process utilities and React component tests.
+
+**Architecture:** Extract testable pure functions from `main.ts` into `src/main/utils.ts`, configure Vitest for both Node (main process) and jsdom (renderer) environments, write tests for all pure functions and key React components.
+
+**Tech Stack:** Vitest, @testing-library/react, @testing-library/jest-dom, jsdom
+
+---
+
+### Task 1: Install test dependencies
+
+**Step 1: Install packages**
+
+Run: `npm install -D vitest @testing-library/react @testing-library/jest-dom jsdom @testing-library/user-event`
+
+**Step 2: Add test script to package.json**
+
+Modify: `package.json` — add to `"scripts"`:
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+**Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add vitest and testing-library dependencies"
+```
+
+---
+
+### Task 2: Create Vitest config
+
+**Files:**
+- Create: `vitest.config.ts`
+
+**Step 1: Create vitest.config.ts**
+
+```ts
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src/renderer'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.{ts,tsx}'],
+    environmentMatchGlobs: [
+      ['src/renderer/**/*.test.tsx', 'jsdom'],
+    ],
+    css: false,
+  },
+});
+```
+
+**Step 2: Commit**
+
+```bash
+git add vitest.config.ts
+git commit -m "chore: add vitest configuration"
+```
+
+---
+
+### Task 3: Extract utility functions from main.ts
+
+The functions `truncate`, `summarizeForLog`, `formatError`, `resolveVaultPath`, and `processToolCall` are currently defined as private functions in `main.ts`. Extract the pure ones into `src/main/utils.ts` so they can be imported in tests.
+
+**Files:**
+- Create: `src/main/utils.ts`
+- Modify: `src/main/main.ts` — import from `./utils` instead of inline definitions
+
+**Step 1: Create `src/main/utils.ts`**
+
+Extract these functions (copy verbatim from main.ts):
+- `truncate(value: string, max?: number): string`
+- `summarizeForLog(value: any, keyHint?: string, depth?: number): any`
+- `formatError(error: any): Record<string, any>`
+
+**Step 2: Update main.ts to import from utils**
+
+Replace inline definitions with:
+```ts
+import { truncate, summarizeForLog, formatError } from './utils';
+```
+
+**Step 3: Verify main process compiles**
+
+Run: `npx tsc -p tsconfig.electron.json`
+Expected: Clean compilation, no errors
+
+**Step 4: Commit**
+
+```bash
+git add src/main/utils.ts src/main/main.ts
+git commit -m "refactor: extract utility functions to src/main/utils.ts"
+```
+
+---
+
+### Task 4: Write tests for `truncate`
+
+**Files:**
+- Create: `src/main/utils.test.ts`
+
+**Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { truncate } from './utils';
+
+describe('truncate', () => {
+  it('returns short strings unchanged', () => {
+    expect(truncate('hello')).toBe('hello');
+  });
+
+  it('truncates strings exceeding default max (220)', () => {
+    const long = 'a'.repeat(300);
+    const result = truncate(long);
+    expect(result).toBe('a'.repeat(220) + '... [len=300]');
+  });
+
+  it('respects custom max length', () => {
+    const result = truncate('abcdefgh', 5);
+    expect(result).toBe('abcde... [len=8]');
+  });
+
+  it('returns string at exact max length unchanged', () => {
+    const exact = 'a'.repeat(220);
+    expect(truncate(exact)).toBe(exact);
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `npx vitest run src/main/utils.test.ts`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/main/utils.test.ts
+git commit -m "test: add truncate utility tests"
+```
+
+---
+
+### Task 5: Write tests for `summarizeForLog`
+
+**Files:**
+- Modify: `src/main/utils.test.ts`
+
+**Step 1: Add tests**
+
+```ts
+describe('summarizeForLog', () => {
+  it('returns null/undefined as-is', () => {
+    expect(summarizeForLog(null)).toBe(null);
+    expect(summarizeForLog(undefined)).toBe(undefined);
+  });
+
+  it('returns numbers and booleans as-is', () => {
+    expect(summarizeForLog(42)).toBe(42);
+    expect(summarizeForLog(true)).toBe(true);
+  });
+
+  it('redacts API key fields', () => {
+    expect(summarizeForLog('sk-secret-key', 'api_key')).toBe('<redacted len=13>');
+    expect(summarizeForLog('secret', 'apiKey')).toBe('<redacted len=6>');
+    expect(summarizeForLog('secret', 'token')).toBe('<redacted len=6>');
+    expect(summarizeForLog('secret', 'password')).toBe('<redacted len=6>');
+    expect(summarizeForLog('secret', 'authorization')).toBe('<redacted len=6>');
+  });
+
+  it('summarizes systemPrompt and content fields', () => {
+    expect(summarizeForLog('long prompt text', 'systemPrompt')).toBe('<systemPrompt len=16>');
+    expect(summarizeForLog('message body', 'content')).toBe('<content len=12>');
+  });
+
+  it('truncates long strings', () => {
+    const long = 'x'.repeat(300);
+    const result = summarizeForLog(long);
+    expect(result).toContain('... [len=300]');
+  });
+
+  it('handles arrays with max 10 items', () => {
+    const arr = Array.from({ length: 15 }, (_, i) => i);
+    const result = summarizeForLog(arr);
+    expect(result).toHaveLength(11); // 10 items + overflow marker
+    expect(result[10]).toBe('[+5 more]');
+  });
+
+  it('recursively summarizes objects', () => {
+    const obj = { apiKey: 'secret', name: 'test' };
+    const result = summarizeForLog(obj);
+    expect(result.apiKey).toBe('<redacted len=6>');
+    expect(result.name).toBe('test');
+  });
+
+  it('stops at depth limit', () => {
+    expect(summarizeForLog('anything', '', 4)).toBe('[depth-limit]');
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `npx vitest run src/main/utils.test.ts`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/main/utils.test.ts
+git commit -m "test: add summarizeForLog utility tests"
+```
+
+---
+
+### Task 6: Write tests for `formatError`
+
+**Files:**
+- Modify: `src/main/utils.test.ts`
+
+**Step 1: Add tests**
+
+```ts
+describe('formatError', () => {
+  it('extracts standard error properties', () => {
+    const error = new Error('something broke');
+    error.name = 'TypeError';
+    const result = formatError(error);
+    expect(result.name).toBe('TypeError');
+    expect(result.message).toBe('something broke');
+    expect(result.stack).toBeDefined();
+  });
+
+  it('handles non-Error values', () => {
+    expect(formatError('string error').message).toBe('string error');
+    expect(formatError(null).message).toBe('null');
+    expect(formatError(undefined).message).toBe('undefined');
+  });
+
+  it('includes code and status if present', () => {
+    const error = { message: 'fail', code: 'ENOENT', status: 404, type: 'not_found' };
+    const result = formatError(error);
+    expect(result.code).toBe('ENOENT');
+    expect(result.status).toBe(404);
+    expect(result.type).toBe('not_found');
+  });
+
+  it('truncates long stack traces', () => {
+    const error = new Error('x');
+    error.stack = 'x'.repeat(1000);
+    const result = formatError(error);
+    expect(result.stack.length).toBeLessThan(600);
+    expect(result.stack).toContain('... [len=1000]');
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `npx vitest run src/main/utils.test.ts`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/main/utils.test.ts
+git commit -m "test: add formatError utility tests"
+```
+
+---
+
+### Task 7: Write tests for provider tool/message conversion
+
+**Files:**
+- Create: `src/main/providers/anthropic.test.ts`
+- Create: `src/main/providers/openai.test.ts`
+
+The conversion methods are private, so we test them indirectly through `buildToolResultMessages` and `getDefaultModels`, plus test the constructor behavior.
+
+**Step 1: Write Anthropic provider tests**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { AnthropicProvider } from './anthropic';
+
+describe('AnthropicProvider', () => {
+  it('has correct id', () => {
+    const provider = new AnthropicProvider();
+    expect(provider.id).toBe('anthropic');
+  });
+
+  it('builds tool result messages in Anthropic format', () => {
+    const provider = new AnthropicProvider();
+    const rawAssistantMessage = [
+      { type: 'text', text: 'Let me check that.' },
+      { type: 'tool_use', id: 'tool_1', name: 'read_file', input: { path: 'tasks.md' } },
+    ];
+    const results = [{ toolCallId: 'tool_1', content: '# Tasks\n- Buy milk' }];
+
+    const messages = provider.buildToolResultMessages(rawAssistantMessage, results);
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe('assistant');
+    expect(messages[0].content).toBe(rawAssistantMessage);
+    expect(messages[1].role).toBe('user');
+    expect(messages[1].content[0].type).toBe('tool_result');
+    expect(messages[1].content[0].tool_use_id).toBe('tool_1');
+  });
+
+  it('returns default models', () => {
+    const provider = new AnthropicProvider();
+    const models = provider.getDefaultModels();
+    expect(models.length).toBeGreaterThan(0);
+    expect(models[0].value).toBe('claude-sonnet-4-5');
+    expect(models.every(m => m.value && m.label)).toBe(true);
+  });
+
+  it('throws when sendMessageStream called without configure', async () => {
+    const provider = new AnthropicProvider();
+    const { result } = provider.sendMessageStream({
+      messages: [{ id: '1', role: 'user', content: 'Hi', timestamp: Date.now() }],
+      systemPrompt: 'test',
+      model: 'claude-sonnet-4-5',
+      tools: [],
+      onText: () => {},
+    });
+    await expect(result).rejects.toThrow('not configured');
+  });
+});
+```
+
+**Step 2: Write OpenAI provider tests**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { OpenAIProvider } from './openai';
+
+describe('OpenAIProvider', () => {
+  it('defaults to openai id', () => {
+    const provider = new OpenAIProvider();
+    expect(provider.id).toBe('openai');
+  });
+
+  it('accepts custom id', () => {
+    const provider = new OpenAIProvider('custom');
+    expect(provider.id).toBe('custom');
+  });
+
+  it('builds tool result messages in OpenAI format', () => {
+    const provider = new OpenAIProvider();
+    const rawAssistantMessage = {
+      role: 'assistant',
+      content: null,
+      tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'read_file', arguments: '{"path":"tasks.md"}' } }],
+    };
+    const results = [{ toolCallId: 'call_1', content: '# Tasks' }];
+
+    const messages = provider.buildToolResultMessages(rawAssistantMessage, results);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toBe(rawAssistantMessage);
+    expect(messages[1].role).toBe('tool');
+    expect(messages[1].tool_call_id).toBe('call_1');
+    expect(messages[1].content).toBe('# Tasks');
+  });
+
+  it('returns correct default models for openai', () => {
+    const provider = new OpenAIProvider('openai');
+    const models = provider.getDefaultModels();
+    expect(models.some(m => m.value === 'gpt-4o')).toBe(true);
+    expect(models.some(m => m.value === 'gpt-4o-mini')).toBe(true);
+  });
+
+  it('returns correct default models for custom', () => {
+    const provider = new OpenAIProvider('custom');
+    const models = provider.getDefaultModels();
+    expect(models).toHaveLength(1);
+    expect(models[0].value).toBe('gpt-4o');
+  });
+
+  it('throws when sendMessageStream called without configure', async () => {
+    const provider = new OpenAIProvider();
+    const { result } = provider.sendMessageStream({
+      messages: [{ id: '1', role: 'user', content: 'Hi', timestamp: Date.now() }],
+      systemPrompt: 'test',
+      model: 'gpt-4o',
+      tools: [],
+      onText: () => {},
+    });
+    await expect(result).rejects.toThrow('not configured');
+  });
+});
+```
+
+**Step 3: Run tests**
+
+Run: `npx vitest run src/main/providers/`
+Expected: All PASS
+
+**Step 4: Commit**
+
+```bash
+git add src/main/providers/anthropic.test.ts src/main/providers/openai.test.ts
+git commit -m "test: add provider unit tests"
+```
+
+---
+
+### Task 8: Write tests for VAULT_TOOLS definition
+
+**Files:**
+- Create: `src/main/providers/tools.test.ts`
+
+**Step 1: Write tests**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { VAULT_TOOLS } from './tools';
+
+describe('VAULT_TOOLS', () => {
+  it('exports 7 tools', () => {
+    expect(VAULT_TOOLS).toHaveLength(7);
+  });
+
+  it('all tools have required fields', () => {
+    for (const tool of VAULT_TOOLS) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+      expect(tool.parameters.type).toBe('object');
+      expect(tool.parameters.properties).toBeDefined();
+      expect(Array.isArray(tool.parameters.required)).toBe(true);
+    }
+  });
+
+  it('includes expected tool names', () => {
+    const names = VAULT_TOOLS.map(t => t.name);
+    expect(names).toContain('read_file');
+    expect(names).toContain('write_file');
+    expect(names).toContain('edit_file');
+    expect(names).toContain('list_files');
+    expect(names).toContain('create_file');
+    expect(names).toContain('move_file');
+    expect(names).toContain('archive_tasks');
+  });
+
+  it('all required params exist in properties', () => {
+    for (const tool of VAULT_TOOLS) {
+      for (const req of tool.parameters.required) {
+        expect(tool.parameters.properties).toHaveProperty(req);
+      }
+    }
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `npx vitest run src/main/providers/tools.test.ts`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/main/providers/tools.test.ts
+git commit -m "test: add VAULT_TOOLS definition tests"
+```
+
+---
+
+### Task 9: Write tests for provider registry
+
+**Files:**
+- Create: `src/main/providers/registry.test.ts`
+
+**Step 1: Write tests**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { getProvider, resetProvider } from './registry';
+
+describe('provider registry', () => {
+  it('returns AnthropicProvider for "anthropic"', async () => {
+    const provider = await getProvider('anthropic');
+    expect(provider.id).toBe('anthropic');
+  });
+
+  it('returns OpenAIProvider for "openai"', async () => {
+    const provider = await getProvider('openai');
+    expect(provider.id).toBe('openai');
+  });
+
+  it('returns OpenAIProvider with custom id for "custom"', async () => {
+    const provider = await getProvider('custom');
+    expect(provider.id).toBe('custom');
+  });
+
+  it('caches provider instances', async () => {
+    const p1 = await getProvider('anthropic');
+    const p2 = await getProvider('anthropic');
+    expect(p1).toBe(p2);
+  });
+
+  it('returns new instance after reset', async () => {
+    const p1 = await getProvider('anthropic');
+    resetProvider('anthropic');
+    const p2 = await getProvider('anthropic');
+    expect(p1).not.toBe(p2);
+  });
+
+  it('throws for unknown provider', async () => {
+    await expect(getProvider('unknown' as any)).rejects.toThrow('Unknown provider');
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `npx vitest run src/main/providers/registry.test.ts`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/main/providers/registry.test.ts
+git commit -m "test: add provider registry tests"
+```
+
+---
+
+### Task 10: Write React component tests — Header
+
+**Files:**
+- Create: `src/renderer/components/Header.test.tsx`
+
+**Step 1: Create test setup file**
+
+Create: `src/renderer/test-setup.ts`
+```ts
+import '@testing-library/jest-dom/vitest';
+```
+
+Update `vitest.config.ts` to include:
+```ts
+setupFiles: ['./src/renderer/test-setup.ts'],
+```
+
+**Step 2: Write Header tests**
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Header from './Header';
+
+describe('Header', () => {
+  const defaultProps = {
+    onToggleExplorer: vi.fn(),
+    onOpenSettings: vi.fn(),
+    onNewChat: vi.fn(),
+    explorerOpen: false,
+  };
+
+  it('renders the app title', () => {
+    render(<Header {...defaultProps} />);
+    expect(screen.getByText('Nudge')).toBeInTheDocument();
+  });
+
+  it('calls onNewChat when + button clicked', async () => {
+    const onNewChat = vi.fn();
+    render(<Header {...defaultProps} onNewChat={onNewChat} />);
+    await userEvent.click(screen.getByTitle('New chat'));
+    expect(onNewChat).toHaveBeenCalledOnce();
+  });
+
+  it('calls onOpenSettings when settings button clicked', async () => {
+    const onOpenSettings = vi.fn();
+    render(<Header {...defaultProps} onOpenSettings={onOpenSettings} />);
+    await userEvent.click(screen.getByTitle('Settings'));
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+  });
+
+  it('calls onToggleExplorer when files button clicked', async () => {
+    const onToggleExplorer = vi.fn();
+    render(<Header {...defaultProps} onToggleExplorer={onToggleExplorer} />);
+    await userEvent.click(screen.getByTitle('Toggle file explorer'));
+    expect(onToggleExplorer).toHaveBeenCalledOnce();
+  });
+
+  it('shows active class when explorer is open', () => {
+    render(<Header {...defaultProps} explorerOpen={true} />);
+    const btn = screen.getByTitle('Toggle file explorer');
+    expect(btn.className).toContain('header-btn--active');
+  });
+
+  it('shows update dot when hasUpdate is true', () => {
+    const { container } = render(<Header {...defaultProps} hasUpdate={true} />);
+    expect(container.querySelector('.header-update-dot')).toBeInTheDocument();
+  });
+
+  it('hides update dot when hasUpdate is false', () => {
+    const { container } = render(<Header {...defaultProps} hasUpdate={false} />);
+    expect(container.querySelector('.header-update-dot')).not.toBeInTheDocument();
+  });
+});
+```
+
+**Step 3: Run tests**
+
+Run: `npx vitest run src/renderer/components/Header.test.tsx`
+Expected: All PASS
+
+**Step 4: Commit**
+
+```bash
+git add src/renderer/test-setup.ts src/renderer/components/Header.test.tsx vitest.config.ts
+git commit -m "test: add Header component tests"
+```
+
+---
+
+### Task 11: Write React component tests — ChatInput
+
+**Files:**
+- Create: `src/renderer/components/ChatInput.test.tsx`
+
+**Step 1: Write tests**
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChatInput from './ChatInput';
+
+describe('ChatInput', () => {
+  it('renders textarea with placeholder', () => {
+    render(<ChatInput onSend={vi.fn()} disabled={false} />);
+    expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
+  });
+
+  it('disables textarea when disabled prop is true', () => {
+    render(<ChatInput onSend={vi.fn()} disabled={true} />);
+    expect(screen.getByPlaceholderText('Type a message...')).toBeDisabled();
+  });
+
+  it('calls onSend with trimmed value on Enter', async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<ChatInput onSend={onSend} disabled={false} />);
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    await user.type(textarea, 'hello world{Enter}');
+    expect(onSend).toHaveBeenCalledWith('hello world');
+  });
+
+  it('does not send on Shift+Enter', async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<ChatInput onSend={onSend} disabled={false} />);
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    await user.type(textarea, 'line one{Shift>}{Enter}{/Shift}line two');
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('does not send empty messages', async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<ChatInput onSend={onSend} disabled={false} />);
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    await user.type(textarea, '   {Enter}');
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('disables send button when input is empty', () => {
+    render(<ChatInput onSend={vi.fn()} disabled={false} />);
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
+  });
+
+  it('clears input after sending', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSend={vi.fn()} disabled={false} />);
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    await user.type(textarea, 'hello{Enter}');
+    expect(textarea).toHaveValue('');
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `npx vitest run src/renderer/components/ChatInput.test.tsx`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/renderer/components/ChatInput.test.tsx
+git commit -m "test: add ChatInput component tests"
+```
+
+---
+
+### Task 12: Write React component tests — ChatPanel
+
+**Files:**
+- Create: `src/renderer/components/ChatPanel.test.tsx`
+
+**Step 1: Write tests**
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChatPanel from './ChatPanel';
+import { ChatMessage } from '../../shared/types';
+
+const makeMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: '1',
+  role: 'user',
+  content: 'Hello',
+  timestamp: Date.now(),
+  ...overrides,
+});
+
+describe('ChatPanel', () => {
+  const defaultProps = {
+    messages: [] as ChatMessage[],
+    isStreaming: false,
+    streamingContent: '',
+    onSendMessage: vi.fn(),
+  };
+
+  it('shows empty state with suggestion chips when no messages', () => {
+    render(<ChatPanel {...defaultProps} />);
+    expect(screen.getByText('What would you like to work on?')).toBeInTheDocument();
+    expect(screen.getByText('Start my day')).toBeInTheDocument();
+    expect(screen.getByText('I have an idea')).toBeInTheDocument();
+  });
+
+  it('sends suggestion chip text on click', async () => {
+    const user = userEvent.setup();
+    const onSendMessage = vi.fn();
+    render(<ChatPanel {...defaultProps} onSendMessage={onSendMessage} />);
+    await user.click(screen.getByText('Start my day'));
+    expect(onSendMessage).toHaveBeenCalledWith('Start my day');
+  });
+
+  it('renders messages when provided', () => {
+    const messages = [
+      makeMessage({ id: '1', role: 'user', content: 'Hi there' }),
+      makeMessage({ id: '2', role: 'assistant', content: 'Hello!' }),
+    ];
+    render(<ChatPanel {...defaultProps} messages={messages} />);
+    expect(screen.getByText('Hi there')).toBeInTheDocument();
+    expect(screen.getByText('Hello!')).toBeInTheDocument();
+  });
+
+  it('shows typing indicator when streaming with no content', () => {
+    const { container } = render(
+      <ChatPanel {...defaultProps} messages={[makeMessage()]} isStreaming={true} streamingContent="" />
+    );
+    expect(container.querySelector('.chat-panel-typing')).toBeInTheDocument();
+  });
+
+  it('shows streaming content when available', () => {
+    render(
+      <ChatPanel {...defaultProps} messages={[makeMessage()]} isStreaming={true} streamingContent="Thinking about..." />
+    );
+    expect(screen.getByText('Thinking about...')).toBeInTheDocument();
+  });
+
+  it('disables input while streaming', () => {
+    render(<ChatPanel {...defaultProps} messages={[makeMessage()]} isStreaming={true} streamingContent="" />);
+    expect(screen.getByPlaceholderText('Type a message...')).toBeDisabled();
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `npx vitest run src/renderer/components/ChatPanel.test.tsx`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/renderer/components/ChatPanel.test.tsx
+git commit -m "test: add ChatPanel component tests"
+```
+
+---
+
+### Task 13: Write React component tests — MessageBubble
+
+**Files:**
+- Create: `src/renderer/components/MessageBubble.test.tsx`
+
+**Step 1: Write tests**
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MessageBubble from './MessageBubble';
+import { ChatMessage } from '../../shared/types';
+
+const makeMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: '1',
+  role: 'user',
+  content: 'Test message',
+  timestamp: Date.now(),
+  ...overrides,
+});
+
+describe('MessageBubble', () => {
+  it('renders message content', () => {
+    render(<MessageBubble message={makeMessage({ content: 'Hello world' })} />);
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('applies user class for user messages', () => {
+    const { container } = render(<MessageBubble message={makeMessage({ role: 'user' })} />);
+    expect(container.querySelector('.message-bubble--user')).toBeInTheDocument();
+  });
+
+  it('applies assistant class for assistant messages', () => {
+    const { container } = render(<MessageBubble message={makeMessage({ role: 'assistant' })} />);
+    expect(container.querySelector('.message-bubble--assistant')).toBeInTheDocument();
+  });
+
+  it('displays formatted timestamp', () => {
+    const timestamp = new Date('2026-02-22T14:30:00').getTime();
+    render(<MessageBubble message={makeMessage({ timestamp })} />);
+    expect(screen.getByText(/2:30/)).toBeInTheDocument();
+  });
+
+  it('renders markdown content', () => {
+    render(<MessageBubble message={makeMessage({ content: '**bold text**' })} />);
+    const strong = screen.getByText('bold text');
+    expect(strong.tagName).toBe('STRONG');
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `npx vitest run src/renderer/components/MessageBubble.test.tsx`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/renderer/components/MessageBubble.test.tsx
+git commit -m "test: add MessageBubble component tests"
+```
+
+---
+
+### Task 14: Run full test suite and verify
+
+**Step 1: Run all tests**
+
+Run: `npx vitest run`
+Expected: All tests pass, 0 failures
+
+**Step 2: Verify TypeScript compilation still works**
+
+Run: `npx tsc -p tsconfig.electron.json`
+Expected: Clean compilation
+
+**Step 3: Final commit if any remaining changes**
+
+```bash
+git add -A
+git commit -m "test: complete test infrastructure setup"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nudge",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nudge",
-      "version": "0.1.2",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
@@ -20,6 +20,9 @@
         "uuid": "^13.0.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.2.3",
         "@types/react": "^19.2.13",
         "@types/react-dom": "^19.2.3",
@@ -28,10 +31,26 @@
         "concurrently": "^9.2.1",
         "electron": "^40.2.1",
         "electron-builder": "^26.7.0",
+        "jsdom": "^28.1.0",
         "typescript": "^5.9.3",
         "vite": "^7.3.1",
+        "vitest": "^4.0.18",
         "wait-on": "^9.0.3"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.74.0",
@@ -52,6 +71,61 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -362,6 +436,151 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+      "integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -1258,6 +1477,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@hapi/address": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
@@ -2017,6 +2254,104 @@
         "node": ">=10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2075,6 +2410,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2083,6 +2429,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2267,6 +2620,117 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -2549,6 +3013,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2558,6 +3032,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astral-regex": {
@@ -2661,6 +3145,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bl": {
@@ -2995,6 +3489,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3355,11 +3859,110 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.2.tgz",
+      "integrity": "sha512-B5xvQYh7n+s/elmwhMOthufrO+QaORHuUoSJGhmogxPz9LNT6HMbou3fUeieOOFogKP84SYryyLC405QvyFvaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3377,6 +3980,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -3629,6 +4239,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -3979,6 +4597,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -4013,6 +4644,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4123,6 +4761,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -4139,6 +4787,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -4743,6 +5401,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -4880,6 +5551,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4995,6 +5676,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -5112,6 +5800,85 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -5277,6 +6044,27 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -5618,6 +6406,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -6238,6 +7033,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
@@ -6617,6 +7422,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6782,6 +7598,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -6825,6 +7654,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pe-library": {
       "version": "0.4.1",
@@ -6968,6 +7804,36 @@
         "node": ">=10"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proc-log": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
@@ -7100,6 +7966,14 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-markdown": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
@@ -7162,6 +8036,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/remark-gfm": {
@@ -7234,6 +8122,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7437,6 +8335,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7515,6 +8426,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -7700,6 +8618,13 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -7709,6 +8634,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -7791,6 +8723,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -7846,6 +8791,13 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tar": {
       "version": "7.5.7",
@@ -8002,6 +8954,23 @@
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8018,6 +8987,36 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.5",
@@ -8037,6 +9036,19 @@
       "license": "MIT",
       "dependencies": {
         "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -8136,6 +9148,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -8453,6 +9475,97 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wait-on": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.3.tgz",
@@ -8498,6 +9611,16 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -8522,6 +9645,23 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -8567,6 +9707,16 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -8576,6 +9726,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "dev:electron": "wait-on http://localhost:5173 && tsc -p tsconfig.electron.json && electron . --dev",
     "build": "tsc -p tsconfig.electron.json && vite build --config vite.config.ts && electron-builder",
     "build:vite": "vite build --config vite.config.ts",
-    "build:electron": "tsc -p tsconfig.electron.json"
+    "build:electron": "tsc -p tsconfig.electron.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "author": "",
   "license": "MIT",
@@ -26,6 +28,9 @@
     "uuid": "^13.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.2.3",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
@@ -34,8 +39,10 @@
     "concurrently": "^9.2.1",
     "electron": "^40.2.1",
     "electron-builder": "^26.7.0",
+    "jsdom": "^28.1.0",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
+    "vitest": "^4.0.18",
     "wait-on": "^9.0.3"
   }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,6 +5,7 @@ import { getProvider, resetProvider } from './providers/registry';
 import { VAULT_TOOLS } from './providers/tools';
 import { ProviderId, UpdateStatus } from './providers/types';
 import { autoUpdater } from 'electron-updater';
+import { truncate, summarizeForLog, formatError } from './utils';
 
 let mainWindow: BrowserWindow | null = null;
 const IS_DEV = process.argv.includes('--dev');
@@ -66,43 +67,6 @@ function setupAutoUpdater(): void {
 const DEV_LOG_DIR = 'logs';
 const DEV_LOG_FILE = 'dev.log';
 
-function truncate(value: string, max = 220): string {
-  if (value.length <= max) return value;
-  return `${value.slice(0, max)}... [len=${value.length}]`;
-}
-
-function summarizeForLog(value: any, keyHint = '', depth = 0): any {
-  if (depth > 3) return '[depth-limit]';
-  if (value === null || value === undefined) return value;
-  if (typeof value === 'number' || typeof value === 'boolean') return value;
-
-  if (typeof value === 'string') {
-    if (/(^|[-_])(api[-_]?key|key|token|password|authorization)($|[-_])/i.test(keyHint)) {
-      return `<redacted len=${value.length}>`;
-    }
-    if (keyHint === 'systemPrompt') return `<systemPrompt len=${value.length}>`;
-    if (keyHint === 'content') return `<content len=${value.length}>`;
-    return truncate(value);
-  }
-
-  if (Array.isArray(value)) {
-    const maxItems = 10;
-    const mapped = value.slice(0, maxItems).map((item) => summarizeForLog(item, '', depth + 1));
-    if (value.length > maxItems) mapped.push(`[+${value.length - maxItems} more]`);
-    return mapped;
-  }
-
-  if (typeof value === 'object') {
-    const obj = value as Record<string, any>;
-    const out: Record<string, any> = {};
-    for (const [k, v] of Object.entries(obj)) {
-      out[k] = summarizeForLog(v, k, depth + 1);
-    }
-    return out;
-  }
-
-  return String(value);
-}
 
 function appendDevLog(line: string): void {
   if (!IS_DEV || !app.isReady()) return;
@@ -131,16 +95,6 @@ function devLog(scope: string, message: string, payload?: any): void {
   appendDevLog(`${base} ${JSON.stringify(summarized)}`);
 }
 
-function formatError(error: any): Record<string, any> {
-  return {
-    name: error?.name,
-    message: error?.message || String(error),
-    code: error?.code,
-    status: error?.status,
-    type: error?.type,
-    stack: error?.stack ? truncate(error.stack, 500) : undefined,
-  };
-}
 
 process.on('uncaughtException', (error) => {
   devLog('process', 'uncaught exception', formatError(error));

--- a/src/main/providers/anthropic.test.ts
+++ b/src/main/providers/anthropic.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { AnthropicProvider } from './anthropic';
+
+describe('AnthropicProvider', () => {
+  it('has correct id', () => {
+    const provider = new AnthropicProvider();
+    expect(provider.id).toBe('anthropic');
+  });
+
+  it('builds tool result messages in Anthropic format', () => {
+    const provider = new AnthropicProvider();
+    const rawAssistantMessage = [
+      { type: 'text', text: 'Let me check that.' },
+      { type: 'tool_use', id: 'tool_1', name: 'read_file', input: { path: 'tasks.md' } },
+    ];
+    const results = [{ toolCallId: 'tool_1', content: '# Tasks\n- Buy milk' }];
+
+    const messages = provider.buildToolResultMessages(rawAssistantMessage, results);
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe('assistant');
+    expect(messages[0].content).toBe(rawAssistantMessage);
+    expect(messages[1].role).toBe('user');
+    expect(messages[1].content[0].type).toBe('tool_result');
+    expect(messages[1].content[0].tool_use_id).toBe('tool_1');
+  });
+
+  it('returns default models', () => {
+    const provider = new AnthropicProvider();
+    const models = provider.getDefaultModels();
+    expect(models.length).toBeGreaterThan(0);
+    expect(models[0].value).toBe('claude-sonnet-4-5');
+    expect(models.every(m => m.value && m.label)).toBe(true);
+  });
+
+  it('throws when sendMessageStream called without configure', async () => {
+    const provider = new AnthropicProvider();
+    const { result } = provider.sendMessageStream({
+      messages: [{ id: '1', role: 'user', content: 'Hi', timestamp: Date.now() }],
+      systemPrompt: 'test',
+      model: 'claude-sonnet-4-5',
+      tools: [],
+      onText: () => {},
+    });
+    await expect(result).rejects.toThrow('not configured');
+  });
+});

--- a/src/main/providers/openai.test.ts
+++ b/src/main/providers/openai.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { OpenAIProvider } from './openai';
+
+describe('OpenAIProvider', () => {
+  it('defaults to openai id', () => {
+    const provider = new OpenAIProvider();
+    expect(provider.id).toBe('openai');
+  });
+
+  it('accepts custom id', () => {
+    const provider = new OpenAIProvider('custom');
+    expect(provider.id).toBe('custom');
+  });
+
+  it('builds tool result messages in OpenAI format', () => {
+    const provider = new OpenAIProvider();
+    const rawAssistantMessage = {
+      role: 'assistant',
+      content: null,
+      tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'read_file', arguments: '{"path":"tasks.md"}' } }],
+    };
+    const results = [{ toolCallId: 'call_1', content: '# Tasks' }];
+
+    const messages = provider.buildToolResultMessages(rawAssistantMessage, results);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toBe(rawAssistantMessage);
+    expect(messages[1].role).toBe('tool');
+    expect(messages[1].tool_call_id).toBe('call_1');
+    expect(messages[1].content).toBe('# Tasks');
+  });
+
+  it('returns correct default models for openai', () => {
+    const provider = new OpenAIProvider('openai');
+    const models = provider.getDefaultModels();
+    expect(models.some(m => m.value === 'gpt-4o')).toBe(true);
+    expect(models.some(m => m.value === 'gpt-4o-mini')).toBe(true);
+  });
+
+  it('returns correct default models for custom', () => {
+    const provider = new OpenAIProvider('custom');
+    const models = provider.getDefaultModels();
+    expect(models).toHaveLength(1);
+    expect(models[0].value).toBe('gpt-4o');
+  });
+
+  it('throws when sendMessageStream called without configure', async () => {
+    const provider = new OpenAIProvider();
+    const { result } = provider.sendMessageStream({
+      messages: [{ id: '1', role: 'user', content: 'Hi', timestamp: Date.now() }],
+      systemPrompt: 'test',
+      model: 'gpt-4o',
+      tools: [],
+      onText: () => {},
+    });
+    await expect(result).rejects.toThrow('not configured');
+  });
+});

--- a/src/main/providers/registry.test.ts
+++ b/src/main/providers/registry.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { getProvider, resetProvider } from './registry';
+
+describe('provider registry', () => {
+  it('returns AnthropicProvider for "anthropic"', async () => {
+    const provider = await getProvider('anthropic');
+    expect(provider.id).toBe('anthropic');
+  });
+
+  it('returns OpenAIProvider for "openai"', async () => {
+    const provider = await getProvider('openai');
+    expect(provider.id).toBe('openai');
+  });
+
+  it('returns OpenAIProvider with custom id for "custom"', async () => {
+    const provider = await getProvider('custom');
+    expect(provider.id).toBe('custom');
+  });
+
+  it('caches provider instances', async () => {
+    const p1 = await getProvider('anthropic');
+    const p2 = await getProvider('anthropic');
+    expect(p1).toBe(p2);
+  });
+
+  it('returns new instance after reset', async () => {
+    const p1 = await getProvider('anthropic');
+    resetProvider('anthropic');
+    const p2 = await getProvider('anthropic');
+    expect(p1).not.toBe(p2);
+  });
+
+  it('throws for unknown provider', async () => {
+    await expect(getProvider('unknown' as any)).rejects.toThrow('Unknown provider');
+  });
+});

--- a/src/main/providers/tools.test.ts
+++ b/src/main/providers/tools.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { VAULT_TOOLS } from './tools';
+
+describe('VAULT_TOOLS', () => {
+  it('exports 7 tools', () => {
+    expect(VAULT_TOOLS).toHaveLength(7);
+  });
+
+  it('all tools have required fields', () => {
+    for (const tool of VAULT_TOOLS) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+      expect(tool.parameters.type).toBe('object');
+      expect(tool.parameters.properties).toBeDefined();
+      expect(Array.isArray(tool.parameters.required)).toBe(true);
+    }
+  });
+
+  it('includes expected tool names', () => {
+    const names = VAULT_TOOLS.map(t => t.name);
+    expect(names).toContain('read_file');
+    expect(names).toContain('write_file');
+    expect(names).toContain('edit_file');
+    expect(names).toContain('list_files');
+    expect(names).toContain('create_file');
+    expect(names).toContain('move_file');
+    expect(names).toContain('archive_tasks');
+  });
+
+  it('all required params exist in properties', () => {
+    for (const tool of VAULT_TOOLS) {
+      for (const req of tool.parameters.required) {
+        expect(tool.parameters.properties).toHaveProperty(req);
+      }
+    }
+  });
+});

--- a/src/main/utils.test.ts
+++ b/src/main/utils.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { truncate, summarizeForLog, formatError } from './utils';
+
+describe('truncate', () => {
+  it('returns short strings unchanged', () => {
+    expect(truncate('hello')).toBe('hello');
+  });
+
+  it('truncates strings exceeding default max (220)', () => {
+    const long = 'a'.repeat(300);
+    const result = truncate(long);
+    expect(result).toBe('a'.repeat(220) + '... [len=300]');
+  });
+
+  it('respects custom max length', () => {
+    const result = truncate('abcdefgh', 5);
+    expect(result).toBe('abcde... [len=8]');
+  });
+
+  it('returns string at exact max length unchanged', () => {
+    const exact = 'a'.repeat(220);
+    expect(truncate(exact)).toBe(exact);
+  });
+});
+
+describe('summarizeForLog', () => {
+  it('returns null/undefined as-is', () => {
+    expect(summarizeForLog(null)).toBe(null);
+    expect(summarizeForLog(undefined)).toBe(undefined);
+  });
+
+  it('returns numbers and booleans as-is', () => {
+    expect(summarizeForLog(42)).toBe(42);
+    expect(summarizeForLog(true)).toBe(true);
+  });
+
+  it('redacts API key fields', () => {
+    expect(summarizeForLog('sk-secret-key', 'api_key')).toBe('<redacted len=13>');
+    expect(summarizeForLog('secret', 'apiKey')).toBe('<redacted len=6>');
+    expect(summarizeForLog('secret', 'token')).toBe('<redacted len=6>');
+    expect(summarizeForLog('secret', 'password')).toBe('<redacted len=6>');
+    expect(summarizeForLog('secret', 'authorization')).toBe('<redacted len=6>');
+  });
+
+  it('summarizes systemPrompt and content fields', () => {
+    expect(summarizeForLog('long prompt text', 'systemPrompt')).toBe('<systemPrompt len=16>');
+    expect(summarizeForLog('message body', 'content')).toBe('<content len=12>');
+  });
+
+  it('truncates long strings', () => {
+    const long = 'x'.repeat(300);
+    const result = summarizeForLog(long);
+    expect(result).toContain('... [len=300]');
+  });
+
+  it('handles arrays with max 10 items', () => {
+    const arr = Array.from({ length: 15 }, (_, i) => i);
+    const result = summarizeForLog(arr);
+    expect(result).toHaveLength(11); // 10 items + overflow marker
+    expect(result[10]).toBe('[+5 more]');
+  });
+
+  it('recursively summarizes objects', () => {
+    const obj = { apiKey: 'secret', name: 'test' };
+    const result = summarizeForLog(obj);
+    expect(result.apiKey).toBe('<redacted len=6>');
+    expect(result.name).toBe('test');
+  });
+
+  it('stops at depth limit', () => {
+    expect(summarizeForLog('anything', '', 4)).toBe('[depth-limit]');
+  });
+});
+
+describe('formatError', () => {
+  it('extracts standard error properties', () => {
+    const error = new Error('something broke');
+    error.name = 'TypeError';
+    const result = formatError(error);
+    expect(result.name).toBe('TypeError');
+    expect(result.message).toBe('something broke');
+    expect(result.stack).toBeDefined();
+  });
+
+  it('handles non-Error values', () => {
+    expect(formatError('string error').message).toBe('string error');
+    expect(formatError(null).message).toBe('null');
+    expect(formatError(undefined).message).toBe('undefined');
+  });
+
+  it('includes code and status if present', () => {
+    const error = { message: 'fail', code: 'ENOENT', status: 404, type: 'not_found' };
+    const result = formatError(error);
+    expect(result.code).toBe('ENOENT');
+    expect(result.status).toBe(404);
+    expect(result.type).toBe('not_found');
+  });
+
+  it('truncates long stack traces', () => {
+    const error = new Error('x');
+    error.stack = 'x'.repeat(1000);
+    const result = formatError(error);
+    expect(result.stack.length).toBeLessThan(600);
+    expect(result.stack).toContain('... [len=1000]');
+  });
+});

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,0 +1,48 @@
+export function truncate(value: string, max = 220): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}... [len=${value.length}]`;
+}
+
+export function summarizeForLog(value: any, keyHint = '', depth = 0): any {
+  if (depth > 3) return '[depth-limit]';
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+
+  if (typeof value === 'string') {
+    if (/(^|[-_])(api[-_]?key|key|token|password|authorization)($|[-_])/i.test(keyHint)) {
+      return `<redacted len=${value.length}>`;
+    }
+    if (keyHint === 'systemPrompt') return `<systemPrompt len=${value.length}>`;
+    if (keyHint === 'content') return `<content len=${value.length}>`;
+    return truncate(value);
+  }
+
+  if (Array.isArray(value)) {
+    const maxItems = 10;
+    const mapped = value.slice(0, maxItems).map((item) => summarizeForLog(item, '', depth + 1));
+    if (value.length > maxItems) mapped.push(`[+${value.length - maxItems} more]`);
+    return mapped;
+  }
+
+  if (typeof value === 'object') {
+    const obj = value as Record<string, any>;
+    const out: Record<string, any> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      out[k] = summarizeForLog(v, k, depth + 1);
+    }
+    return out;
+  }
+
+  return String(value);
+}
+
+export function formatError(error: any): Record<string, any> {
+  return {
+    name: error?.name,
+    message: error?.message || String(error),
+    code: error?.code,
+    status: error?.status,
+    type: error?.type,
+    stack: error?.stack ? truncate(error.stack, 500) : undefined,
+  };
+}

--- a/src/renderer/components/ChatInput.test.tsx
+++ b/src/renderer/components/ChatInput.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChatInput from './ChatInput';
+
+describe('ChatInput', () => {
+  it('renders textarea with placeholder', () => {
+    render(<ChatInput onSend={vi.fn()} disabled={false} />);
+    expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
+  });
+
+  it('disables textarea when disabled prop is true', () => {
+    render(<ChatInput onSend={vi.fn()} disabled={true} />);
+    expect(screen.getByPlaceholderText('Type a message...')).toBeDisabled();
+  });
+
+  it('calls onSend with trimmed value on Enter', async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<ChatInput onSend={onSend} disabled={false} />);
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    await user.type(textarea, 'hello world{Enter}');
+    expect(onSend).toHaveBeenCalledWith('hello world');
+  });
+
+  it('does not send on Shift+Enter', async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<ChatInput onSend={onSend} disabled={false} />);
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    await user.type(textarea, 'line one{Shift>}{Enter}{/Shift}line two');
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('does not send empty messages', async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<ChatInput onSend={onSend} disabled={false} />);
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    await user.type(textarea, '   {Enter}');
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('disables send button when input is empty', () => {
+    render(<ChatInput onSend={vi.fn()} disabled={false} />);
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
+  });
+
+  it('clears input after sending', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSend={vi.fn()} disabled={false} />);
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    await user.type(textarea, 'hello{Enter}');
+    expect(textarea).toHaveValue('');
+  });
+});

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChatPanel from './ChatPanel';
+import { ChatMessage } from '../../shared/types';
+
+const makeMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: '1',
+  role: 'user',
+  content: 'Hello',
+  timestamp: Date.now(),
+  ...overrides,
+});
+
+describe('ChatPanel', () => {
+  const defaultProps = {
+    messages: [] as ChatMessage[],
+    isStreaming: false,
+    streamingContent: '',
+    onSendMessage: vi.fn(),
+  };
+
+  it('shows empty state with suggestion chips when no messages', () => {
+    render(<ChatPanel {...defaultProps} />);
+    expect(screen.getByText('What would you like to work on?')).toBeInTheDocument();
+    expect(screen.getByText('Start my day')).toBeInTheDocument();
+    expect(screen.getByText('I have an idea')).toBeInTheDocument();
+  });
+
+  it('sends suggestion chip text on click', async () => {
+    const user = userEvent.setup();
+    const onSendMessage = vi.fn();
+    render(<ChatPanel {...defaultProps} onSendMessage={onSendMessage} />);
+    await user.click(screen.getByText('Start my day'));
+    expect(onSendMessage).toHaveBeenCalledWith('Start my day');
+  });
+
+  it('renders messages when provided', () => {
+    const messages = [
+      makeMessage({ id: '1', role: 'user', content: 'Hi there' }),
+      makeMessage({ id: '2', role: 'assistant', content: 'Hello!' }),
+    ];
+    render(<ChatPanel {...defaultProps} messages={messages} />);
+    expect(screen.getByText('Hi there')).toBeInTheDocument();
+    expect(screen.getByText('Hello!')).toBeInTheDocument();
+  });
+
+  it('shows typing indicator when streaming with no content', () => {
+    const { container } = render(
+      <ChatPanel {...defaultProps} messages={[makeMessage()]} isStreaming={true} streamingContent="" />
+    );
+    expect(container.querySelector('.chat-panel-typing')).toBeInTheDocument();
+  });
+
+  it('shows streaming content when available', () => {
+    render(
+      <ChatPanel {...defaultProps} messages={[makeMessage()]} isStreaming={true} streamingContent="Thinking about..." />
+    );
+    expect(screen.getByText('Thinking about...')).toBeInTheDocument();
+  });
+
+  it('disables input while streaming', () => {
+    render(<ChatPanel {...defaultProps} messages={[makeMessage()]} isStreaming={true} streamingContent="" />);
+    expect(screen.getByPlaceholderText('Type a message...')).toBeDisabled();
+  });
+});

--- a/src/renderer/components/Header.test.tsx
+++ b/src/renderer/components/Header.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Header from './Header';
+
+describe('Header', () => {
+  const defaultProps = {
+    onToggleExplorer: vi.fn(),
+    onOpenSettings: vi.fn(),
+    onNewChat: vi.fn(),
+    explorerOpen: false,
+  };
+
+  it('renders the app title', () => {
+    render(<Header {...defaultProps} />);
+    expect(screen.getByText('Nudge')).toBeInTheDocument();
+  });
+
+  it('calls onNewChat when + button clicked', async () => {
+    const onNewChat = vi.fn();
+    render(<Header {...defaultProps} onNewChat={onNewChat} />);
+    await userEvent.click(screen.getByTitle('New chat'));
+    expect(onNewChat).toHaveBeenCalledOnce();
+  });
+
+  it('calls onOpenSettings when settings button clicked', async () => {
+    const onOpenSettings = vi.fn();
+    render(<Header {...defaultProps} onOpenSettings={onOpenSettings} />);
+    await userEvent.click(screen.getByTitle('Settings'));
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+  });
+
+  it('calls onToggleExplorer when files button clicked', async () => {
+    const onToggleExplorer = vi.fn();
+    render(<Header {...defaultProps} onToggleExplorer={onToggleExplorer} />);
+    await userEvent.click(screen.getByTitle('Toggle file explorer'));
+    expect(onToggleExplorer).toHaveBeenCalledOnce();
+  });
+
+  it('shows active class when explorer is open', () => {
+    render(<Header {...defaultProps} explorerOpen={true} />);
+    const btn = screen.getByTitle('Toggle file explorer');
+    expect(btn.className).toContain('header-btn--active');
+  });
+
+  it('shows update dot when hasUpdate is true', () => {
+    const { container } = render(<Header {...defaultProps} hasUpdate={true} />);
+    expect(container.querySelector('.header-update-dot')).toBeInTheDocument();
+  });
+
+  it('hides update dot when hasUpdate is false', () => {
+    const { container } = render(<Header {...defaultProps} hasUpdate={false} />);
+    expect(container.querySelector('.header-update-dot')).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/MessageBubble.test.tsx
+++ b/src/renderer/components/MessageBubble.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MessageBubble from './MessageBubble';
+import { ChatMessage } from '../../shared/types';
+
+const makeMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: '1',
+  role: 'user',
+  content: 'Test message',
+  timestamp: Date.now(),
+  ...overrides,
+});
+
+describe('MessageBubble', () => {
+  it('renders message content', () => {
+    render(<MessageBubble message={makeMessage({ content: 'Hello world' })} />);
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('applies user class for user messages', () => {
+    const { container } = render(<MessageBubble message={makeMessage({ role: 'user' })} />);
+    expect(container.querySelector('.message-bubble--user')).toBeInTheDocument();
+  });
+
+  it('applies assistant class for assistant messages', () => {
+    const { container } = render(<MessageBubble message={makeMessage({ role: 'assistant' })} />);
+    expect(container.querySelector('.message-bubble--assistant')).toBeInTheDocument();
+  });
+
+  it('displays formatted timestamp', () => {
+    const timestamp = new Date('2026-02-22T14:30:00').getTime();
+    render(<MessageBubble message={makeMessage({ timestamp })} />);
+    expect(screen.getByText(/2:30/)).toBeInTheDocument();
+  });
+
+  it('renders markdown content', () => {
+    render(<MessageBubble message={makeMessage({ content: '**bold text**' })} />);
+    const strong = screen.getByText('bold text');
+    expect(strong.tagName).toBe('STRONG');
+  });
+});

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -1,1 +1,20 @@
 import '@testing-library/jest-dom/vitest';
+
+// jsdom doesn't implement window.matchMedia or Element.scrollIntoView
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+
+  Element.prototype.scrollIntoView = () => {};
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src/renderer'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.{ts,tsx}'],
+    environmentMatchGlobs: [
+      ['src/renderer/**/*.test.tsx', 'jsdom'],
+    ],
+    setupFiles: ['./src/renderer/test-setup.ts'],
+    css: false,
+  },
+});


### PR DESCRIPTION
## Summary
- Set up Vitest with dual environment (node for main process, jsdom for React components)
- Extracted `truncate`, `summarizeForLog`, `formatError` from `main.ts` into `src/main/utils.ts` for testability
- Added 61 tests across 9 test files — all passing

## What's tested
**Main process (36 tests):** utility functions, provider tool/message conversion, registry caching, VAULT_TOOLS schema
**React components (25 tests):** Header, ChatInput, ChatPanel, MessageBubble — rendering, user interactions, streaming states

## Test plan
- [x] `npm test` — 61/61 passing
- [x] `npx tsc -p tsconfig.electron.json` — clean compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)