### PR TITLE
v0.1.6: Context menu, line wrap, checklist tasks, auto-refresh

### DIFF
--- a/app-bundle/system-prompt.md
+++ b/app-bundle/system-prompt.md
@@ -55,7 +55,7 @@ When the user says "start my day", "morning review", or similar:
 4. Check tasks.md for unchecked Today and Recurring items
 5. Reset Recurring Daily checkboxes (uncheck for the new day)
 6. If it's Monday, reset Recurring Weekly checkboxes
-7. Surface 3-5 approachable suggestions — prioritize high-priority items first, then filter by energy level for the time of day and size. Low-priority items should only appear if nothing higher-priority fits the current energy/time.
+7. Surface 3-5 approachable suggestions as `- [ ]` checkboxes — prioritize high-priority items first, then filter by energy level for the time of day and size. Low-priority items should only appear if nothing higher-priority fits the current energy/time.
 8. Let the user pick, skip, or ask for different options
 9. Create today's daily log with chosen items
 10. Occasionally suggest an exercise break as part of the day
@@ -81,7 +81,7 @@ When the user says "I have an idea" or describes a project:
 
 1. Listen to the description
 2. Ask minimal clarifying questions for frontmatter (size, energy, type, tags) only if not obvious. Infer priority from context — "urgent", "blocking", "deadline" → high; "someday", "when I get to it", "no rush" → low; everything else → medium. Never ask about priority directly.
-3. Create a new file in ideas/ with proper frontmatter, title, "What is it?", and "What does starting look like?" with at least one tiny step
+3. Create a new file in ideas/ with proper frontmatter, title, "What is it?", and "What does starting look like?" with at least one tiny step as a `- [ ]` checkbox
 4. Confirm the idea is saved
 5. Keep it quick
 
@@ -215,6 +215,17 @@ The vault has a fixed directory structure. **Never create new directories.** The
 - Never add new sections to the idea template or `tasks.md` file.
 
 If in doubt: small actionable items → `tasks.md`, bigger ideas/projects → `ideas/`, everything else → ask the user.
+
+## Task Formatting Rule
+
+**ALWAYS use markdown checklist format for tasks, action items, steps, and to-do lists.** Every actionable item you generate — whether in tasks.md, idea files ("What does starting look like?"), daily logs, morning review suggestions, or inline in conversation — MUST use the `- [ ]` checkbox syntax:
+
+```
+- [ ] Something to do
+- [ ] Another thing to do
+```
+
+This applies everywhere you list things a user could act on. People with ADHD get a real dopamine hit from checking things off — it matters. Never use plain bullet points (`- `) or numbered lists (`1.`) for actionable items. Informational lists that are not tasks can still use plain bullets.
 
 ## Important Rules
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nudge",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nudge",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nudge",
   "productName": "Nudge",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "An ADHD-aware desktop app for managing ideas and daily planning through conversational AI",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -120,6 +120,7 @@ function loadSettings(): Record<string, any> {
     model: 'claude-sonnet-4-5',
     activeProvider: 'anthropic',
     onboardingComplete: false,
+    editorLineWrap: true,
   };
 }
 
@@ -230,10 +231,17 @@ ipcMain.handle('vault:read-frontmatter', async (_event, relativePath: string) =>
   return frontmatter;
 });
 
+function notifyVaultChanged(): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('vault:changed');
+  }
+}
+
 ipcMain.handle('vault:write-file', async (_event, relativePath: string, content: string) => {
   const fullPath = resolveVaultPath(relativePath);
   ensureDir(path.dirname(fullPath));
   fs.writeFileSync(fullPath, content, 'utf-8');
+  notifyVaultChanged();
 });
 
 ipcMain.handle('vault:edit-file', async (_event, relativePath: string, oldText: string, newText: string) => {
@@ -244,6 +252,7 @@ ipcMain.handle('vault:edit-file', async (_event, relativePath: string, oldText: 
   }
   const updated = content.replace(oldText, newText);
   fs.writeFileSync(fullPath, updated, 'utf-8');
+  notifyVaultChanged();
 });
 
 ipcMain.handle('vault:list-files', async (_event, directory: string) => {
@@ -268,6 +277,7 @@ ipcMain.handle('vault:create-file', async (_event, relativePath: string, content
     throw new Error(`File already exists: ${relativePath}`);
   }
   fs.writeFileSync(fullPath, content, 'utf-8');
+  notifyVaultChanged();
 });
 
 ipcMain.handle('vault:move-file', async (_event, sourcePath: string, destPath: string) => {
@@ -281,6 +291,28 @@ ipcMain.handle('vault:move-file', async (_event, sourcePath: string, destPath: s
   }
   ensureDir(path.dirname(fullDest));
   fs.renameSync(fullSource, fullDest);
+  notifyVaultChanged();
+});
+
+ipcMain.handle('vault:delete-file', async (_event, relativePath: string) => {
+  const fullPath = resolveVaultPath(relativePath);
+  if (!fs.existsSync(fullPath)) {
+    throw new Error(`File not found: ${relativePath}`);
+  }
+  await fs.promises.unlink(fullPath);
+  notifyVaultChanged();
+});
+
+ipcMain.handle('vault:list-directories', async () => {
+  const vaultPath = getVaultPath();
+  if (!fs.existsSync(vaultPath)) {
+    return [];
+  }
+  const entries = fs.readdirSync(vaultPath, { withFileTypes: true });
+  return entries
+    .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+    .map(e => e.name)
+    .sort();
 });
 
 ipcMain.handle('vault:get-path', async () => {
@@ -488,6 +520,7 @@ async function processToolCall(toolName: string, toolInput: Record<string, strin
       if (!fullPath.startsWith(vaultPath)) throw new Error('Path outside vault');
       ensureDir(path.dirname(fullPath));
       fs.writeFileSync(fullPath, toolInput.content, 'utf-8');
+      notifyVaultChanged();
       return `File written: ${toolInput.path}`;
     }
     case 'edit_file': {
@@ -496,6 +529,7 @@ async function processToolCall(toolName: string, toolInput: Record<string, strin
       const content = fs.readFileSync(fullPath, 'utf-8');
       if (!content.includes(toolInput.old_text)) return `Error: Text not found in ${toolInput.path}`;
       fs.writeFileSync(fullPath, content.replace(toolInput.old_text, toolInput.new_text), 'utf-8');
+      notifyVaultChanged();
       return `File edited: ${toolInput.path}`;
     }
     case 'list_files': {
@@ -515,6 +549,7 @@ async function processToolCall(toolName: string, toolInput: Record<string, strin
       if (fs.existsSync(fullPath)) return `Error: File already exists: ${toolInput.path}`;
       ensureDir(path.dirname(fullPath));
       fs.writeFileSync(fullPath, toolInput.content, 'utf-8');
+      notifyVaultChanged();
       return `File created: ${toolInput.path}`;
     }
     case 'move_file': {
@@ -526,6 +561,7 @@ async function processToolCall(toolName: string, toolInput: Record<string, strin
       if (fs.existsSync(destPath)) return `Error: Destination file already exists: ${toolInput.destination}`;
       ensureDir(path.dirname(destPath));
       fs.renameSync(srcPath, destPath);
+      notifyVaultChanged();
       return `File moved: ${toolInput.source} → ${toolInput.destination}`;
     }
     case 'archive_tasks': {
@@ -582,6 +618,7 @@ async function processToolCall(toolName: string, toolInput: Record<string, strin
         fs.writeFileSync(archivePath, header + `\n${dateMarker}\n\n` + archivedContent, 'utf-8');
       }
 
+      notifyVaultChanged();
       return `Archived ${completedTasks.length} completed task(s) under ${toolInput.date}.`;
     }
     default:

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -139,6 +139,13 @@ contextBridge.exposeInMainWorld('nudge', {
     listFiles: (directory: string) => invoke('vault:list-files', directory),
     createFile: (path: string, content: string) => invoke('vault:create-file', path, content),
     moveFile: (source: string, destination: string) => invoke('vault:move-file', source, destination),
+    deleteFile: (path: string) => invoke<void>('vault:delete-file', path),
+    listDirectories: () => invoke<string[]>('vault:list-directories'),
+    onChanged: (callback: () => void) => {
+      const handler = () => callback();
+      ipcRenderer.on('vault:changed', handler);
+      return () => { ipcRenderer.removeListener('vault:changed', handler); };
+    },
     getPath: () => invoke('vault:get-path'),
     initialize: (path: string) => invoke('vault:initialize', path),
     exists: (path: string) => invoke('vault:exists', path),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -264,6 +264,7 @@ export default function App() {
             isOpen={explorerOpen}
             onClose={() => setExplorerOpen(false)}
             onFileSelect={(path) => setEditingFile(path)}
+            editingFile={editingFile}
           />
         )}
 

--- a/src/renderer/components/ContextMenu.tsx
+++ b/src/renderer/components/ContextMenu.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useRef, useCallback } from 'react';
+import '../styles/ContextMenu.css';
+
+export interface ContextMenuItem {
+  label: string;
+  onClick: () => void;
+  danger?: boolean;
+  disabled?: boolean;
+  submenu?: ContextMenuItem[];
+}
+
+export interface ContextMenuSeparator {
+  separator: true;
+}
+
+export type ContextMenuEntry = ContextMenuItem | ContextMenuSeparator;
+
+function isSeparator(entry: ContextMenuEntry): entry is ContextMenuSeparator {
+  return 'separator' in entry;
+}
+
+interface ContextMenuProps {
+  x: number;
+  y: number;
+  items: ContextMenuEntry[];
+  onClose: () => void;
+}
+
+export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const adjustPosition = useCallback(() => {
+    if (!menuRef.current) return;
+    const rect = menuRef.current.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let adjustedX = x;
+    let adjustedY = y;
+
+    if (x + rect.width > viewportWidth) {
+      adjustedX = viewportWidth - rect.width - 8;
+    }
+    if (y + rect.height > viewportHeight) {
+      adjustedY = viewportHeight - rect.height - 8;
+    }
+
+    menuRef.current.style.left = `${adjustedX}px`;
+    menuRef.current.style.top = `${adjustedY}px`;
+  }, [x, y]);
+
+  useEffect(() => {
+    adjustPosition();
+  }, [adjustPosition]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="context-menu"
+      style={{ left: x, top: y }}
+    >
+      {items.map((entry, i) => {
+        if (isSeparator(entry)) {
+          return <div key={`sep-${i}`} className="context-menu-separator" />;
+        }
+        const item = entry as ContextMenuItem;
+        return (
+          <div
+            key={item.label}
+            className={
+              `context-menu-item` +
+              (item.danger ? ' context-menu-item--danger' : '') +
+              (item.disabled ? ' context-menu-item--disabled' : '')
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!item.disabled) {
+                item.onClick();
+                onClose();
+              }
+            }}
+          >
+            {item.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/renderer/components/FileEditor.tsx
+++ b/src/renderer/components/FileEditor.tsx
@@ -127,7 +127,7 @@ export default function FileEditor({ filePath, onClose }: FileEditorProps) {
   const [loading, setLoading] = useState(false);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('saved');
   const [showLineNumbers, setShowLineNumbers] = useState(true);
-  const [wordWrap, setWordWrap] = useState(false);
+  const [wordWrap, setWordWrap] = useState(true);
   const [scrollTop, setScrollTop] = useState(0);
   const [lineHeights, setLineHeights] = useState<number[] | null>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -137,6 +137,22 @@ export default function FileEditor({ filePath, onClose }: FileEditorProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const editorBodyRef = useRef<HTMLDivElement>(null);
   const isDark = useIsDark();
+
+  // Load persisted line wrap setting
+  useEffect(() => {
+    window.nudge.settings.get('editorLineWrap').then((val: any) => {
+      // Default to true if not yet set
+      setWordWrap(val !== false);
+    });
+  }, []);
+
+  const handleWordWrapToggle = useCallback(() => {
+    setWordWrap(prev => {
+      const next = !prev;
+      window.nudge.settings.set('editorLineWrap', next);
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     if (!filePath) return;
@@ -351,7 +367,7 @@ export default function FileEditor({ filePath, onClose }: FileEditorProps) {
         </button>
         <button
           className={`file-editor-line-toggle ${wordWrap ? 'active' : ''}`}
-          onClick={() => setWordWrap(prev => !prev)}
+          onClick={handleWordWrapToggle}
           title={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none">

--- a/src/renderer/components/FileExplorer.tsx
+++ b/src/renderer/components/FileExplorer.tsx
@@ -1,10 +1,12 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import ContextMenu, { ContextMenuEntry } from './ContextMenu';
 import '../styles/FileExplorer.css';
 
 interface FileExplorerProps {
   isOpen: boolean;
   onClose: () => void;
-  onFileSelect: (path: string) => void;
+  onFileSelect: (path: string | null) => void;
+  editingFile?: string | null;
 }
 
 interface TreeEntry {
@@ -16,10 +18,29 @@ interface TreeEntry {
   loaded?: boolean;
 }
 
-export default function FileExplorer({ isOpen, onClose, onFileSelect }: FileExplorerProps) {
+interface ContextMenuState {
+  x: number;
+  y: number;
+  filePath: string;
+  fileName: string;
+}
+
+export default function FileExplorer({ isOpen, onClose, onFileSelect, editingFile }: FileExplorerProps) {
   const [entries, setEntries] = useState<TreeEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [priorities, setPriorities] = useState<Record<string, string>>({});
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const [renamingPath, setRenamingPath] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [moveSubmenuPath, setMoveSubmenuPath] = useState<string | null>(null);
+  const [directories, setDirectories] = useState<string[]>([]);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+  const entriesRef = useRef<TreeEntry[]>([]);
+
+  // Keep ref in sync with state
+  useEffect(() => {
+    entriesRef.current = entries;
+  }, [entries]);
 
   const loadDirectory = useCallback(async (directory: string): Promise<TreeEntry[]> => {
     try {
@@ -64,19 +85,73 @@ export default function FileExplorer({ isOpen, onClose, onFileSelect }: FileExpl
     setPriorities(newPriorities);
   }, []);
 
+  const getExpandedPaths = useCallback((items: TreeEntry[]): Set<string> => {
+    const expanded = new Set<string>();
+    const walk = (entries: TreeEntry[]) => {
+      for (const entry of entries) {
+        if (entry.isDirectory && entry.expanded) {
+          expanded.add(entry.path);
+          if (entry.children) walk(entry.children);
+        }
+      }
+    };
+    walk(items);
+    return expanded;
+  }, []);
+
+  const restoreExpanded = useCallback(async (root: TreeEntry[], expandedPaths: Set<string>): Promise<TreeEntry[]> => {
+    const restore = async (items: TreeEntry[]): Promise<TreeEntry[]> => {
+      return Promise.all(items.map(async (item) => {
+        if (item.isDirectory && expandedPaths.has(item.path)) {
+          const children = await loadDirectory(item.path);
+          const restoredChildren = await restore(children);
+          return { ...item, children: restoredChildren, loaded: true, expanded: true };
+        }
+        return item;
+      }));
+    };
+    return restore(root);
+  }, [loadDirectory]);
+
   const loadRoot = useCallback(async () => {
     setLoading(true);
+    const expandedPaths = getExpandedPaths(entriesRef.current);
     const root = await loadDirectory('');
-    setEntries(root);
+    const restored = expandedPaths.size > 0 ? await restoreExpanded(root, expandedPaths) : root;
+    setEntries(restored);
     setLoading(false);
-    loadPriorities(root).catch(() => {});
-  }, [loadDirectory, loadPriorities]);
+    loadPriorities(restored).catch(() => {});
+  }, [loadDirectory, loadPriorities, getExpandedPaths, restoreExpanded]);
 
   useEffect(() => {
     if (isOpen) {
       loadRoot();
     }
+  }, [isOpen]);
+
+  // Auto-refresh on vault changes
+  useEffect(() => {
+    if (!isOpen) return;
+    const cleanup = window.nudge.vault.onChanged(() => {
+      loadRoot();
+    });
+    return cleanup;
   }, [isOpen, loadRoot]);
+
+  // Focus and select rename input when renaming starts
+  useEffect(() => {
+    if (renamingPath && renameInputRef.current) {
+      const input = renameInputRef.current;
+      input.focus();
+      // Select name without extension
+      const dotIndex = renameValue.lastIndexOf('.');
+      if (dotIndex > 0) {
+        input.setSelectionRange(0, dotIndex);
+      } else {
+        input.select();
+      }
+    }
+  }, [renamingPath, renameValue]);
 
   const toggleDirectory = async (entry: TreeEntry) => {
     if (!entry.isDirectory) return;
@@ -109,11 +184,172 @@ export default function FileExplorer({ isOpen, onClose, onFileSelect }: FileExpl
     }
   };
 
+  const getParentDir = (filePath: string): string => {
+    const lastSlash = filePath.lastIndexOf('/');
+    return lastSlash > 0 ? filePath.substring(0, lastSlash) : '';
+  };
+
+  const handleContextMenu = (e: React.MouseEvent, entry: TreeEntry) => {
+    if (entry.isDirectory) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setContextMenu({ x: e.clientX, y: e.clientY, filePath: entry.path, fileName: entry.name });
+    setMoveSubmenuPath(null);
+  };
+
+  const closeContextMenu = () => {
+    setContextMenu(null);
+    setMoveSubmenuPath(null);
+  };
+
+  // --- Rename ---
+  const startRename = (filePath: string, fileName: string) => {
+    setRenamingPath(filePath);
+    setRenameValue(fileName);
+    closeContextMenu();
+  };
+
+  const confirmRename = async () => {
+    if (!renamingPath || !renameValue.trim()) {
+      cancelRename();
+      return;
+    }
+    const newName = renameValue.trim();
+    const parentDir = getParentDir(renamingPath);
+    const newPath = parentDir ? `${parentDir}/${newName}` : newName;
+    if (newPath !== renamingPath) {
+      try {
+        await window.nudge.vault.moveFile(renamingPath, newPath);
+        // If the renamed file was being edited, update the editor
+        if (editingFile === renamingPath) {
+          onFileSelect(newPath);
+        }
+        await loadRoot();
+      } catch (err: any) {
+        console.error('Rename failed:', err?.message || err);
+      }
+    }
+    setRenamingPath(null);
+    setRenameValue('');
+  };
+
+  const cancelRename = () => {
+    setRenamingPath(null);
+    setRenameValue('');
+  };
+
+  // --- Duplicate ---
+  const duplicateFile = async (filePath: string, fileName: string) => {
+    closeContextMenu();
+    try {
+      const content = await window.nudge.vault.readFile(filePath);
+      const dotIndex = fileName.lastIndexOf('.');
+      let newName: string;
+      if (dotIndex > 0) {
+        const baseName = fileName.substring(0, dotIndex);
+        const ext = fileName.substring(dotIndex);
+        newName = `${baseName} (copy)${ext}`;
+      } else {
+        newName = `${fileName} (copy)`;
+      }
+      const parentDir = getParentDir(filePath);
+      const newPath = parentDir ? `${parentDir}/${newName}` : newName;
+      await window.nudge.vault.createFile(newPath, content);
+      await loadRoot();
+    } catch (err: any) {
+      console.error('Duplicate failed:', err?.message || err);
+    }
+  };
+
+  // --- Move to... ---
+  const openMoveSubmenu = async (filePath: string) => {
+    try {
+      const dirs = await window.nudge.vault.listDirectories();
+      setDirectories(dirs);
+      setMoveSubmenuPath(filePath);
+    } catch {
+      setDirectories([]);
+    }
+  };
+
+  const moveToDirectory = async (filePath: string, fileName: string, targetDir: string) => {
+    closeContextMenu();
+    try {
+      const newPath = `${targetDir}/${fileName}`;
+      await window.nudge.vault.moveFile(filePath, newPath);
+      if (editingFile === filePath) {
+        onFileSelect(newPath);
+      }
+      await loadRoot();
+    } catch (err: any) {
+      console.error('Move failed:', err?.message || err);
+    }
+  };
+
+  // --- Delete ---
+  const deleteFile = async (filePath: string) => {
+    closeContextMenu();
+    const confirmed = window.confirm(`Delete "${filePath}"? This cannot be undone.`);
+    if (!confirmed) return;
+    try {
+      await window.nudge.vault.deleteFile(filePath);
+      if (editingFile === filePath) {
+        onFileSelect(null);
+      }
+      await loadRoot();
+    } catch (err: any) {
+      console.error('Delete failed:', err?.message || err);
+    }
+  };
+
+  const buildContextMenuItems = (): ContextMenuEntry[] => {
+    if (!contextMenu) return [];
+    const { filePath, fileName } = contextMenu;
+    const currentDir = getParentDir(filePath);
+
+    const items: ContextMenuEntry[] = [
+      { label: 'Rename', onClick: () => startRename(filePath, fileName) },
+      { label: 'Duplicate', onClick: () => duplicateFile(filePath, fileName) },
+    ];
+
+    // Move to... with submenu
+    if (moveSubmenuPath === filePath) {
+      items.push({ separator: true });
+      for (const dir of directories) {
+        const isCurrentDir = dir === currentDir;
+        items.push({
+          label: `Move to ${dir}/`,
+          onClick: () => moveToDirectory(filePath, fileName, dir),
+          disabled: isCurrentDir,
+        });
+      }
+      // Also allow moving to root
+      const isRoot = currentDir === '';
+      items.push({
+        label: 'Move to / (root)',
+        onClick: () => moveToDirectory(filePath, fileName, ''),
+        disabled: isRoot,
+      });
+      items.push({ separator: true });
+    } else {
+      items.push({ label: 'Move to...', onClick: () => openMoveSubmenu(filePath) });
+      items.push({ separator: true });
+    }
+
+    items.push({ label: 'Delete', onClick: () => deleteFile(filePath), danger: true });
+
+    return items;
+  };
+
   const renderEntry = (entry: TreeEntry) => (
     <div key={entry.path}>
       <div
         className={`file-explorer-item ${entry.isDirectory ? 'file-explorer-item--dir' : ''}`}
-        onClick={() => handleClick(entry)}
+        onClick={() => {
+          if (renamingPath === entry.path) return;
+          handleClick(entry);
+        }}
+        onContextMenu={(e) => handleContextMenu(e, entry)}
       >
         {entry.isDirectory && (
           <span className={`file-explorer-chevron ${entry.expanded ? 'file-explorer-chevron--open' : ''}`}>
@@ -123,7 +359,25 @@ export default function FileExplorer({ isOpen, onClose, onFileSelect }: FileExpl
         <span className="file-explorer-icon">
           {entry.isDirectory ? '\uD83D\uDCC1' : '\uD83D\uDCC4'}
         </span>
-        <span className="file-explorer-name">{entry.name}</span>
+        {renamingPath === entry.path ? (
+          <input
+            ref={renameInputRef}
+            className="file-explorer-rename-input"
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                confirmRename();
+              } else if (e.key === 'Escape') {
+                cancelRename();
+              }
+            }}
+            onBlur={confirmRename}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ) : (
+          <span className="file-explorer-name">{entry.name}</span>
+        )}
         {priorities[entry.path] && (
           <span className={`file-explorer-priority file-explorer-priority--${priorities[entry.path]}`} />
         )}
@@ -163,6 +417,14 @@ export default function FileExplorer({ isOpen, onClose, onFileSelect }: FileExpl
           <div className="file-explorer-empty">No files found</div>
         )}
       </div>
+      {contextMenu && (
+        <ContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          items={buildContextMenuItems()}
+          onClose={closeContextMenu}
+        />
+      )}
     </div>
   );
 }

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -83,6 +83,7 @@ export default function Settings({ isOpen, onClose }: SettingsProps) {
   const [appVersion, setAppVersion] = useState('');
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ state: 'idle' });
   const [autoCheckUpdates, setAutoCheckUpdates] = useState(true);
+  const [editorLineWrap, setEditorLineWrap] = useState(true);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -115,6 +116,9 @@ export default function Settings({ isOpen, onClose }: SettingsProps) {
         const autoCheck = await window.nudge.settings.get('autoCheckUpdates');
         setAutoCheckUpdates(autoCheck !== false);
 
+        const lineWrap = await window.nudge.settings.get('editorLineWrap');
+        setEditorLineWrap(lineWrap !== false);
+
         const status = await window.nudge.updater.getStatus();
         setUpdateStatus(status);
       } catch {
@@ -146,6 +150,12 @@ export default function Settings({ isOpen, onClose }: SettingsProps) {
 
     return () => clearTimeout(timer);
   }, [updateStatus.state]);
+
+  const handleEditorLineWrapToggle = async () => {
+    const newValue = !editorLineWrap;
+    setEditorLineWrap(newValue);
+    await window.nudge.settings.set('editorLineWrap', newValue);
+  };
 
   const handleAutoCheckToggle = async () => {
     const newValue = !autoCheckUpdates;
@@ -373,6 +383,24 @@ export default function Settings({ isOpen, onClose }: SettingsProps) {
                 </button>
               ))}
             </div>
+          </div>
+
+          {/* Editor */}
+          <div className="settings-section">
+            <label className="settings-label">Editor</label>
+            <div className="settings-toggle-row">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={editorLineWrap}
+                  onChange={handleEditorLineWrapToggle}
+                />
+                Line wrap
+              </label>
+            </div>
+            <p className="settings-description" style={{ marginTop: 4 }}>
+              Wrap long lines in the markdown editor instead of scrolling horizontally.
+            </p>
           </div>
 
           <div className="settings-divider" />

--- a/src/renderer/styles/ContextMenu.css
+++ b/src/renderer/styles/ContextMenu.css
@@ -1,0 +1,43 @@
+.context-menu {
+  position: fixed;
+  z-index: 10000;
+  min-width: 160px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 4px 16px var(--shadow), 0 1px 4px var(--shadow);
+  padding: 4px 0;
+  font-size: 13px;
+}
+
+.context-menu-item {
+  padding: 6px 14px;
+  cursor: pointer;
+  color: var(--text-primary);
+  transition: background 100ms ease;
+  user-select: none;
+}
+
+.context-menu-item:hover {
+  background: var(--bg-hover);
+}
+
+.context-menu-item--danger:hover {
+  background: #e53e3e20;
+  color: #e53e3e;
+}
+
+.context-menu-item--disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.context-menu-item--disabled:hover {
+  background: transparent;
+}
+
+.context-menu-separator {
+  height: 1px;
+  background: var(--border-light);
+  margin: 4px 0;
+}

--- a/src/renderer/styles/FileExplorer.css
+++ b/src/renderer/styles/FileExplorer.css
@@ -129,3 +129,16 @@
 .file-explorer-priority--low {
   background: var(--priority-low, #a0aec0);
 }
+
+.file-explorer-rename-input {
+  flex: 1;
+  min-width: 0;
+  padding: 1px 4px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--text-primary);
+  background: var(--bg-input);
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  outline: none;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,6 +32,7 @@ export interface AppSettings {
   activeProvider: ProviderId;
   onboardingComplete: boolean;
   autoCheckUpdates: boolean;
+  editorLineWrap: boolean;
 }
 
 export interface UpdateInfo {
@@ -75,6 +76,9 @@ export interface NudgeAPI {
     listFiles: (directory: string) => Promise<string[]>;
     createFile: (path: string, content: string) => Promise<void>;
     moveFile: (source: string, destination: string) => Promise<void>;
+    deleteFile: (path: string) => Promise<void>;
+    listDirectories: () => Promise<string[]>;
+    onChanged: (callback: () => void) => () => void;
     getPath: () => Promise<string>;
     initialize: (path: string) => Promise<void>;
     exists: (path: string) => Promise<boolean>;


### PR DESCRIPTION
## Summary

- **Context menu (#25)** — Right-click files in the explorer for rename, duplicate, move to, and delete. New `ContextMenu` component, `vault:delete-file` and `vault:list-directories` IPC handlers.
- **Line wrap (#36)** — Editor line wrap on by default, persisted via `editorLineWrap` setting, toggleable from both the editor toolbar and Settings.
- **Checklist tasks (#37)** — System prompt enforces `- [ ]` markdown checklist format for all AI-generated tasks and action items.
- **Auto-refresh & preserve state (#38)** — File explorer auto-refreshes on any vault change (including AI tool use), and preserves expanded folder state across refreshes.

## Test plan

- [ ] Right-click a file → context menu appears; right-click a folder → nothing
- [ ] Rename, duplicate, move, delete all work correctly
- [ ] Editor line wrap defaults to ON for new installs
- [ ] Line wrap toggle persists in Settings and editor toolbar
- [ ] AI-generated tasks use `- [ ]` checklist format
- [ ] File explorer refreshes automatically when AI creates/edits files
- [ ] Expanded folders stay expanded after refresh
- [ ] `npx tsc -p tsconfig.electron.json` passes
- [ ] `npx vite build --config vite.config.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)