### PR TITLE
v0.1.7: Fix Move context menu, replace with Archive

### DIFF
--- a/.github/workflows/release-electron.yml
+++ b/.github/workflows/release-electron.yml
@@ -33,6 +33,10 @@ jobs:
         include:
           - os: macos-latest
             platform: mac
+            arch: arm64
+          - os: macos-13
+            platform: mac
+            arch: x64
           - os: ubuntu-latest
             platform: linux
           - os: windows-latest
@@ -62,7 +66,7 @@ jobs:
       # --- macOS signing & notarization ---
       - name: Build Electron app (macOS)
         if: matrix.platform == 'mac'
-        run: npx electron-builder --mac --publish never
+        run: npx electron-builder --mac --arch ${{ matrix.arch }} --publish never
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -212,7 +216,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-${{ matrix.platform }}
+          name: release-${{ matrix.platform }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}
           path: |
             release/*.dmg
             release/*.zip
@@ -270,9 +274,17 @@ jobs:
           }
 
           # macOS (auto-updater requires zip, not dmg)
-          ZIP=$(ls *.zip 2>/dev/null | head -1)
-          if [ -n "$ZIP" ]; then
-            generate_metadata "$ZIP" "latest-mac.yml"
+          ZIP_ARM=$(ls *-arm64*.zip 2>/dev/null | head -1)
+          if [ -n "$ZIP_ARM" ]; then
+            generate_metadata "$ZIP_ARM" "latest-mac.yml"
+          fi
+
+          ZIP_X64=$(ls *-x64*.zip 2>/dev/null | head -1)
+          if [ -z "$ZIP_X64" ]; then
+            ZIP_X64=$(ls *.zip 2>/dev/null | grep -v arm64 | head -1)
+          fi
+          if [ -n "$ZIP_X64" ]; then
+            generate_metadata "$ZIP_X64" "latest-mac-x64.yml"
           fi
 
           # Windows
@@ -313,6 +325,7 @@ jobs:
             artifacts/SHA256SUMS.txt
             artifacts/latest.yml
             artifacts/latest-mac.yml
+            artifacts/latest-mac-x64.yml
             artifacts/latest-linux.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-electron.yml
+++ b/.github/workflows/release-electron.yml
@@ -66,7 +66,7 @@ jobs:
       # --- macOS signing & notarization ---
       - name: Build Electron app (macOS)
         if: matrix.platform == 'mac'
-        run: npx electron-builder --mac --arch ${{ matrix.arch }} --publish never
+        run: npx electron-builder --mac --${{ matrix.arch }} --publish never
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nudge",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nudge",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nudge",
   "productName": "Nudge",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "An ADHD-aware desktop app for managing ideas and daily planning through conversational AI",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -303,18 +303,6 @@ ipcMain.handle('vault:delete-file', async (_event, relativePath: string) => {
   notifyVaultChanged();
 });
 
-ipcMain.handle('vault:list-directories', async () => {
-  const vaultPath = getVaultPath();
-  if (!fs.existsSync(vaultPath)) {
-    return [];
-  }
-  const entries = fs.readdirSync(vaultPath, { withFileTypes: true });
-  return entries
-    .filter(e => e.isDirectory() && !e.name.startsWith('.'))
-    .map(e => e.name)
-    .sort();
-});
-
 ipcMain.handle('vault:get-path', async () => {
   return getVaultPath();
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -140,7 +140,6 @@ contextBridge.exposeInMainWorld('nudge', {
     createFile: (path: string, content: string) => invoke('vault:create-file', path, content),
     moveFile: (source: string, destination: string) => invoke('vault:move-file', source, destination),
     deleteFile: (path: string) => invoke<void>('vault:delete-file', path),
-    listDirectories: () => invoke<string[]>('vault:list-directories'),
     onChanged: (callback: () => void) => {
       const handler = () => callback();
       ipcRenderer.on('vault:changed', handler);

--- a/src/renderer/components/ContextMenu.tsx
+++ b/src/renderer/components/ContextMenu.tsx
@@ -6,7 +6,6 @@ export interface ContextMenuItem {
   onClick: () => void;
   danger?: boolean;
   disabled?: boolean;
-  submenu?: ContextMenuItem[];
 }
 
 export interface ContextMenuSeparator {

--- a/src/renderer/components/FileExplorer.tsx
+++ b/src/renderer/components/FileExplorer.tsx
@@ -32,8 +32,6 @@ export default function FileExplorer({ isOpen, onClose, onFileSelect, editingFil
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
-  const [moveSubmenuPath, setMoveSubmenuPath] = useState<string | null>(null);
-  const [directories, setDirectories] = useState<string[]>([]);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const entriesRef = useRef<TreeEntry[]>([]);
 
@@ -194,12 +192,10 @@ export default function FileExplorer({ isOpen, onClose, onFileSelect, editingFil
     e.preventDefault();
     e.stopPropagation();
     setContextMenu({ x: e.clientX, y: e.clientY, filePath: entry.path, fileName: entry.name });
-    setMoveSubmenuPath(null);
   };
 
   const closeContextMenu = () => {
     setContextMenu(null);
-    setMoveSubmenuPath(null);
   };
 
   // --- Rename ---
@@ -261,28 +257,20 @@ export default function FileExplorer({ isOpen, onClose, onFileSelect, editingFil
     }
   };
 
-  // --- Move to... ---
-  const openMoveSubmenu = async (filePath: string) => {
-    try {
-      const dirs = await window.nudge.vault.listDirectories();
-      setDirectories(dirs);
-      setMoveSubmenuPath(filePath);
-    } catch {
-      setDirectories([]);
-    }
-  };
-
-  const moveToDirectory = async (filePath: string, fileName: string, targetDir: string) => {
+  // --- Archive ---
+  const archiveFile = async (filePath: string, fileName: string) => {
     closeContextMenu();
+    const confirmed = window.confirm('Are you sure you\'d like to archive this file?');
+    if (!confirmed) return;
     try {
-      const newPath = `${targetDir}/${fileName}`;
+      const newPath = `archive/${fileName}`;
       await window.nudge.vault.moveFile(filePath, newPath);
       if (editingFile === filePath) {
-        onFileSelect(newPath);
+        onFileSelect(null);
       }
       await loadRoot();
     } catch (err: any) {
-      console.error('Move failed:', err?.message || err);
+      console.error('Archive failed:', err?.message || err);
     }
   };
 
@@ -307,35 +295,18 @@ export default function FileExplorer({ isOpen, onClose, onFileSelect, editingFil
     const { filePath, fileName } = contextMenu;
     const currentDir = getParentDir(filePath);
 
+    const isIdea = currentDir === 'ideas';
+
     const items: ContextMenuEntry[] = [
       { label: 'Rename', onClick: () => startRename(filePath, fileName) },
       { label: 'Duplicate', onClick: () => duplicateFile(filePath, fileName) },
     ];
 
-    // Move to... with submenu
-    if (moveSubmenuPath === filePath) {
-      items.push({ separator: true });
-      for (const dir of directories) {
-        const isCurrentDir = dir === currentDir;
-        items.push({
-          label: `Move to ${dir}/`,
-          onClick: () => moveToDirectory(filePath, fileName, dir),
-          disabled: isCurrentDir,
-        });
-      }
-      // Also allow moving to root
-      const isRoot = currentDir === '';
-      items.push({
-        label: 'Move to / (root)',
-        onClick: () => moveToDirectory(filePath, fileName, ''),
-        disabled: isRoot,
-      });
-      items.push({ separator: true });
-    } else {
-      items.push({ label: 'Move to...', onClick: () => openMoveSubmenu(filePath) });
-      items.push({ separator: true });
+    if (isIdea) {
+      items.push({ label: 'Archive', onClick: () => archiveFile(filePath, fileName) });
     }
 
+    items.push({ separator: true });
     items.push({ label: 'Delete', onClick: () => deleteFile(filePath), danger: true });
 
     return items;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -77,7 +77,6 @@ export interface NudgeAPI {
     createFile: (path: string, content: string) => Promise<void>;
     moveFile: (source: string, destination: string) => Promise<void>;
     deleteFile: (path: string) => Promise<void>;
-    listDirectories: () => Promise<string[]>;
     onChanged: (callback: () => void) => () => void;
     getPath: () => Promise<string>;
     initialize: (path: string) => Promise<void>;


### PR DESCRIPTION
## Summary

- Replace broken "Move to..." context menu with simple "Archive" action for idea files
- Archive moves idea to `archive/` with confirmation: "Are you sure you'd like to archive this file?"
- Remove unused `vault:list-directories` IPC handler, preload bridge, and type

Closes #41

## Test plan

- [ ] Right-click an idea file → context menu shows Rename, Duplicate, Archive, Delete
- [ ] Right-click a non-idea file → context menu shows Rename, Duplicate, Delete (no Archive)
- [ ] Click Archive → confirmation dialog appears
- [ ] Confirm → file moves to `archive/`, editor closes if it was open
- [ ] Cancel → nothing happens
- [ ] `npx tsc -p tsconfig.electron.json` passes
- [ ] `npx vite build --config vite.config.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)